### PR TITLE
Fix re-downloading of LanguageTool on Windows because of non-standardized folder path

### DIFF
--- a/language_tool_python/utils.py
+++ b/language_tool_python/utils.py
@@ -68,8 +68,10 @@ def correct(text: str, matches: [Match]) -> str:
 
 def get_language_tool_download_path():
     # Get download path from environment or use default.
-    download_path = os.environ.get('LTP_PATH', '~/.cache/language_tool_python/')
-    download_path = os.path.expanduser(download_path)
+    download_path = os.environ.get(
+        'LTP_PATH',
+        os.path.join(os.path.expanduser("~"), ".cache", "language_tool_python")
+    )
     # Make download path, if it doesn't exist.
     os.makedirs(download_path, exist_ok=True)
     return download_path


### PR DESCRIPTION
Before the change in this pull request, this [if statement](https://github.com/jxmorris12/language_tool_python/blob/e3e633513de9b336650b4df47b83da2f4a12965e/language_tool_python/download_lt.py#L151-L152) 

```python
    if extract_path in old_path_list:
        return
```

wrongly evaluated as `False` because the download path was not standardized, as demonstrated in the following example:

```python
>>> print(extract_path)
'C:\\Users\\Tuomas/.cache/language_tool_python/LanguageTool-5.0'

>>> print(old_path_list)
['C:\\Users\\Tuomas/.cache/language_tool_python\\LanguageTool-5.0']
```