### PR TITLE
Fixing a problem where language_tool_python would not start if "java is not installed" even if it is on Windows

### DIFF
--- a/language_tool_python/download_lt.py
+++ b/language_tool_python/download_lt.py
@@ -69,11 +69,14 @@ def confirm_java_compatibility():
     """ Confirms Java major version >= 8. """
     java_path = find_executable('java')
     if not java_path:
-        # Just ignore this and assume an old version of Java. It might not be
-        # found because of a PATHEXT-related issue
-        # (https://bugs.python.org/issue2200).
-        raise ModuleNotFoundError('No java install detected. Please install java to use language-tool-python.')
-
+        if not os.path.isfile('C://Program Files (x86)/Common Files/Oracle/Java/javapath/java.exe'): # Check if 
+            # Just ignore this and assume an old version of Java. It might not be
+            # found because of a PATHEXT-related issue
+            # (https://bugs.python.org/issue2200).
+            raise ModuleNotFoundError('No java install detected. Please install java to use language-tool-python.')
+        else:
+            java_path = 'C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\javapath\\java.exe' # Need to hardcode the path for some Windows users because java is not found by find_executable()
+            
     output = subprocess.check_output([java_path, '-version'],
                                      stderr=subprocess.STDOUT,
                                      universal_newlines=True)

--- a/language_tool_python/utils.py
+++ b/language_tool_python/utils.py
@@ -112,7 +112,7 @@ def get_jar_info():
             if not os.path.isfile('C://Program Files (x86)/Common Files/Oracle/Java/javapath/java.exe'):
                 raise JavaError("Can't find Java")
             else:
-		        java_path = 'C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\javapath\\java.exe'
+                java_path = 'C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\javapath\\java.exe'
 	dir_name = get_language_tool_directory()
         jar_path = None
         for jar_name in JAR_NAMES:

--- a/language_tool_python/utils.py
+++ b/language_tool_python/utils.py
@@ -109,8 +109,11 @@ def get_jar_info():
     except KeyError:
         java_path = which('java')
         if not java_path:
-            raise JavaError("can't find Java")
-        dir_name = get_language_tool_directory()
+            if not os.path.isfile('C://Program Files (x86)/Common Files/Oracle/Java/javapath/java.exe'):
+                raise JavaError("Can't find Java")
+            else:
+		java_path = 'C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\javapath\\java.exe'
+	dir_name = get_language_tool_directory()
         jar_path = None
         for jar_name in JAR_NAMES:
             for jar_path in glob.glob(os.path.join(dir_name, jar_name)):

--- a/language_tool_python/utils.py
+++ b/language_tool_python/utils.py
@@ -112,7 +112,7 @@ def get_jar_info():
             if not os.path.isfile('C://Program Files (x86)/Common Files/Oracle/Java/javapath/java.exe'):
                 raise JavaError("Can't find Java")
             else:
-		java_path = 'C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\javapath\\java.exe'
+		        java_path = 'C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\javapath\\java.exe'
 	dir_name = get_language_tool_directory()
         jar_path = None
         for jar_name in JAR_NAMES:

--- a/language_tool_python/utils.py
+++ b/language_tool_python/utils.py
@@ -113,7 +113,7 @@ def get_jar_info():
                 raise JavaError("Can't find Java")
             else:
                 java_path = 'C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\javapath\\java.exe'
-	dir_name = get_language_tool_directory()
+        dir_name = get_language_tool_directory()
         jar_path = None
         for jar_name in JAR_NAMES:
             for jar_path in glob.glob(os.path.join(dir_name, jar_name)):


### PR DESCRIPTION
I just found that on an old Windows laptop that I had, language_tool_python would not run, telling me that java is not installed, even if it is.

It might be some problems with `find_executable` and `which` in download_lt.py and utils.py so I hard coded java's path for Windows and I make it so that it runs only when a file (the executable) exists.