### PR TITLE
Fix Enabled Rules

### DIFF
--- a/language_tool_python/__main__.py
+++ b/language_tool_python/__main__.py
@@ -142,7 +142,7 @@ def main():
 
         lang_tool.disabled_rules.update(args.disable)
         lang_tool.enabled_rules.update(args.enable)
-        lang_tool.enabled_only = args.enabled_only
+        lang_tool.enabled_rules_only = args.enabled_only
 
         try:
             if args.apply:

--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -105,9 +105,9 @@ class LanguageTool:
         if self.disabled_rules:
             params['disabledRules'] = ','.join(self.disabled_rules)
         if self.enabled_rules:
-            params['enabled'] = ','.join(self.enabled_rules)
+            params['enabledRules'] = ','.join(self.enabled_rules)
         if self.enabled_rules_only:
-            params['enabledOnly'] = 'yes'
+            params['enabledOnly'] = 'true'
         if self.disabled_categories:
             params['disabledCategories'] = ','.join(self.disabled_categories)
         if self.enabled_categories:


### PR DESCRIPTION
### Changes
Fixes `enabledOnly` and `enabledRules` so that it no longer raises an error:
```python
from language_tool_python import LanguageTool
lt = LanguageTool()
lt.enabled_rules_only = True
lt.enabled_rules = {'MORFOLOGIK_RULE_EN_US'}
lt.check("text")
```