### PR TITLE
Fix Bash Tests

### DIFF
--- a/tests/test_local.bash
+++ b/tests/test_local.bash
@@ -6,19 +6,24 @@ set -ex
 
 trap "echo -e '\x1b[01;31mFailed\x1b[0m'" ERR
 
-echo 'This is okay.' | python -m language_tool_python -
-! echo 'This is noot okay.' | python -m language_tool_python -
+exit_status=0
 
-echo 'This is okay.' | python -m language_tool_python -
-! echo 'This is noot okay.' | python -m language_tool_python -
+echo 'This is okay.' | python -m language_tool_python - || exit_status=1
+echo 'This is noot okay.' | python -m language_tool_python - && exit_status=1
 
-echo 'These are “smart” quotes.' | python -m language_tool_python -
-! echo 'These are "dumb" quotes.' | python -m language_tool_python -
-! echo 'These are "dumb" quotes.' | python -m language_tool_python --enabled-only \
-    --enable=EN_QUOTES -
+echo 'This is okay.' | python -m language_tool_python - || exit_status=1
+echo 'This is noot okay.' | python -m language_tool_python - && exit_status=1
+
+echo 'These are “smart” quotes.' | python -m language_tool_python - || exit_status=1
+echo 'These are "dumb" quotes.' | python -m language_tool_python - && exit_status=1
 echo 'These are "dumb" quotes.' | python -m language_tool_python --enabled-only \
-    --enable=EN_UNPAIRED_BRACKETS -
+    --enable=EN_QUOTES - && exit_status=1
+echo 'These are "dumb" quotes.' | python -m language_tool_python --enabled-only \
+    --enable=EN_UNPAIRED_BRACKETS - || exit_status=1
 
-echo '# These are "dumb".' | python -m language_tool_python --ignore-lines='^#' -
+echo '# These are "dumb".' | python -m language_tool_python --ignore-lines='^#' - || exit_status=1
 
-echo -e '\x1b[01;32mOkay\x1b[0m'
+if [[ "$exit_status" == 0 ]]; then
+  echo -e '\x1b[01;32mOkay\x1b[0m'
+fi
+exit "$exit_status"

--- a/tests/test_remote.bash
+++ b/tests/test_remote.bash
@@ -16,8 +16,12 @@ clean ()
 }
 trap clean EXIT
 
-echo 'This is okay.' | \
-    python -m language_tool_python --remote-host localhost --remote-port "$port" -
+exit_status=0
 
-! echo 'This is noot okay.' | \
-    python -m language_tool_python --remote-host localhost --remote-port "$port" -
+echo 'This is okay.' | \
+    python -m language_tool_python --remote-host localhost --remote-port "$port" - || exit_status=1
+
+echo 'This is noot okay.' | \
+    python -m language_tool_python --remote-host localhost --remote-port "$port" - && exit_status=1
+
+exit "$exit_status"


### PR DESCRIPTION
### Changes

Fixes bash tests such that they now exit with with the appropriate error code. Previously, some failed tests would not cause the test scripts to exit with a non-zero exit code. This can be seen [here](https://github.com/jxmorris12/language_tool_python/runs/1682568040). Tests failing appropriately can be seen [here](https://github.com/jxmorris12/language_tool_python/runs/1684727772). Once #33 is merged, the tests should pass on this branch.