### PR TITLE
Session-only New Spellings

### DIFF
--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -152,7 +152,8 @@ class LanguageTool:
         spelling_file_path = self._get_valid_spelling_file_path()
         with open(spelling_file_path, "a+") as spellings_file:
             spellings_file.write("\n" + "\n".join([word for word in spellings]))
-        print("Registered new spellings at {}".format(spelling_file_path))
+        if DEBUG_MODE:
+            print("Registered new spellings at {}".format(spelling_file_path))
 
     def _unregister_spellings(self):
         spelling_file_path = self._get_valid_spelling_file_path()
@@ -164,7 +165,8 @@ class LanguageTool:
                 spellings_file.seek(spellings_file.tell() - 2, os.SEEK_SET)
             spellings_file.seek(spellings_file.tell() + 1, os.SEEK_SET)
             spellings_file.truncate()
-        print("Unregistered new spellings at {}".format(spelling_file_path))
+        if DEBUG_MODE:
+            print("Unregistered new spellings at {}".format(spelling_file_path))
 
     def _get_languages(self) -> set:
         """Get supported languages (by querying the server)."""

--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -33,9 +33,9 @@ class LanguageTool:
     _instances = WeakValueDictionary()
     _PORT_RE = re.compile(r"(?:https?://.*:|port\s+)(\d+)", re.I)
     
-    def __init__(self, language=None, motherTongue=None, remote_server=None, newSpellings=None):
+    def __init__(self, language=None, motherTongue=None, remote_server=None, newSpellings=None, new_spellings_persist=True):
         self._new_spellings = None
-        self.new_spellings_only_current_session = False
+        self._new_spellings_persist = new_spellings_persist
         if newSpellings:
             self._new_spellings = newSpellings
             self._register_spellings(self._new_spellings)
@@ -73,8 +73,8 @@ class LanguageTool:
     def close(self):
         if not self._instances and self._server_is_alive():
             self._terminate_server()
-        if self.new_spellings_only_current_session and self._new_spellings:
-            self.new_spellings_only_current_session = False
+        if not self._new_spellings_persist and self._new_spellings:
+            self._new_spellings = []
             self._unregister_spellings()
 
     @property

--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -34,10 +34,11 @@ class LanguageTool:
     _PORT_RE = re.compile(r"(?:https?://.*:|port\s+)(\d+)", re.I)
     
     def __init__(self, language=None, motherTongue=None, remote_server=None, newSpellings=None):
+        self._new_spellings = None
         if newSpellings:
-            self.new_spellings = newSpellings
+            self._new_spellings = newSpellings
             self.new_spellings_only_current_session = False
-            self._register_spellings(self.new_spellings)
+            self._register_spellings(self._new_spellings)
         if remote_server is not None:
             self._remote = True
             self._url = parse_url(remote_server)
@@ -72,7 +73,7 @@ class LanguageTool:
     def close(self):
         if not self._instances and self._server_is_alive():
             self._terminate_server()
-        if self.new_spellings_only_current_session:
+        if self.new_spellings_only_current_session and self._new_spellings:
             self.new_spellings_only_current_session = False
             self._unregister_spellings()
 
@@ -157,7 +158,7 @@ class LanguageTool:
         spelling_file_path = self._get_valid_spelling_file_path()
         with open(spelling_file_path, 'r+') as spellings_file:
             spellings_file.seek(0, os.SEEK_END)
-            for _ in range(len(self.new_spellings)):
+            for _ in range(len(self._new_spellings)):
                 while spellings_file.read(1) != '\n':
                     spellings_file.seek(spellings_file.tell() - 2, os.SEEK_SET)
                 spellings_file.seek(spellings_file.tell() - 2, os.SEEK_SET)

--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -35,7 +35,9 @@ class LanguageTool:
     
     def __init__(self, language=None, motherTongue=None, remote_server=None, newSpellings=None):
         if newSpellings:
-            self._register_spellings(newSpellings)
+            self.new_spellings = newSpellings
+            self.new_spellings_only_current_session = False
+            self._register_spellings(self.new_spellings)
         if remote_server is not None:
             self._remote = True
             self._url = parse_url(remote_server)
@@ -57,13 +59,22 @@ class LanguageTool:
         self.enabled_rules_only = False
         self._instances[id(self)] = self
 
-    def __del__(self):
-        if not self._instances and self._server_is_alive():
-            self._terminate_server()
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
     def __repr__(self):
         return '{}(language={!r}, motherTongue={!r})'.format(
             self.__class__.__name__, self.language, self.motherTongue)
+
+    def close(self):
+        if not self._instances and self._server_is_alive():
+            self._terminate_server()
+        if self.new_spellings_only_current_session:
+            self.new_spellings_only_current_session = False
+            self._unregister_spellings()
 
     @property
     def language(self):
@@ -126,14 +137,33 @@ class LanguageTool:
         """Disable spell-checking rules."""
         self.disabled_categories.update(self._spell_checking_categories)
 
-    def _register_spellings(self, spellings):
+    @staticmethod
+    def _get_valid_spelling_file_path() -> str:
         library_path = get_language_tool_directory()
         spelling_file_path = os.path.join(library_path, "org/languagetool/resource/en/hunspell/spelling.txt")
         if not os.path.exists(spelling_file_path):
-            raise FileNotFoundError("Failed to find the spellings file at {}\n Please file an issue at https://github.com/jxmorris12/language_tool_python".format(spelling_file_path))
+            raise FileNotFoundError("Failed to find the spellings file at {}\n Please file an issue at "
+                                    "https://github.com/jxmorris12/language_tool_python/issues"
+                                    .format(spelling_file_path))
+        return spelling_file_path
+
+    def _register_spellings(self, spellings):
+        spelling_file_path = self._get_valid_spelling_file_path()
         with open(spelling_file_path, "a+") as spellings_file:
             spellings_file.write("\n" + "\n".join([word for word in spellings]))
-        print("Updated the spellings at {}".format(spelling_file_path))
+        print("Registered new spellings at {}".format(spelling_file_path))
+
+    def _unregister_spellings(self):
+        spelling_file_path = self._get_valid_spelling_file_path()
+        with open(spelling_file_path, 'r+') as spellings_file:
+            spellings_file.seek(0, os.SEEK_END)
+            for _ in range(len(self.new_spellings)):
+                while spellings_file.read(1) != '\n':
+                    spellings_file.seek(spellings_file.tell() - 2, os.SEEK_SET)
+                spellings_file.seek(spellings_file.tell() - 2, os.SEEK_SET)
+            spellings_file.seek(spellings_file.tell() + 1, os.SEEK_SET)
+            spellings_file.truncate()
+        print("Unregistered new spellings at {}".format(spelling_file_path))
 
     def _get_languages(self) -> set:
         """Get supported languages (by querying the server)."""

--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -35,9 +35,9 @@ class LanguageTool:
     
     def __init__(self, language=None, motherTongue=None, remote_server=None, newSpellings=None):
         self._new_spellings = None
+        self.new_spellings_only_current_session = False
         if newSpellings:
             self._new_spellings = newSpellings
-            self.new_spellings_only_current_session = False
             self._register_spellings(self._new_spellings)
         if remote_server is not None:
             self._remote = True

--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -74,8 +74,8 @@ class LanguageTool:
         if not self._instances and self._server_is_alive():
             self._terminate_server()
         if not self._new_spellings_persist and self._new_spellings:
-            self._new_spellings = []
             self._unregister_spellings()
+            self._new_spellings = []
 
     @property
     def language(self):

--- a/tests/test_major_functionality.py
+++ b/tests/test_major_functionality.py
@@ -70,8 +70,7 @@ def test_session_only_new_spellings():
 	initial_checksum = hashlib.sha256(initial_spelling_file_contents.encode())
 
 	new_spellings = ["word1", "word2", "word3"]
-	with language_tool_python.LanguageTool('en-US', newSpellings=new_spellings) as tool:
-		tool.new_spellings_only_current_session = True
+	with language_tool_python.LanguageTool('en-US', newSpellings=new_spellings, new_spellings_persist=False) as tool:
 		tool.enabled_rules_only = True
 		tool.enabled_rules = {'MORFOLOGIK_RULE_EN_US'}
 		matches = tool.check(" ".join(new_spellings))

--- a/tests/test_major_functionality.py
+++ b/tests/test_major_functionality.py
@@ -59,6 +59,34 @@ def test_spellcheck_en_gb():
 	tool.disable_spellchecking()
 	assert tool.correct(s) == "Wat is wrong with the spll chker"
 
+def test_session_only_new_spellings():
+	import os
+	import hashlib
+	import language_tool_python
+	library_path = language_tool_python.utils.get_language_tool_directory()
+	spelling_file_path = os.path.join(library_path, "org/languagetool/resource/en/hunspell/spelling.txt")
+	with open(spelling_file_path, 'r') as spelling_file:
+		initial_spelling_file_contents = spelling_file.read()
+	initial_checksum = hashlib.sha256(initial_spelling_file_contents.encode())
+
+	new_spellings = ["word1", "word2", "word3"]
+	with language_tool_python.LanguageTool('en-US', newSpellings=new_spellings) as tool:
+		tool.new_spellings_only_current_session = True
+		tool.enabled_rules_only = True
+		tool.enabled_rules = {'MORFOLOGIK_RULE_EN_US'}
+		matches = tool.check(" ".join(new_spellings))
+
+	with open(spelling_file_path, 'r') as spelling_file:
+		subsequent_spelling_file_contents = spelling_file.read()
+	subsequent_checksum = hashlib.sha256(subsequent_spelling_file_contents.encode())
+
+	if initial_checksum != subsequent_checksum:
+		with open(spelling_file_path, 'w') as spelling_file:
+			spelling_file.write(initial_spelling_file_contents)
+
+	assert not matches
+	assert initial_checksum.hexdigest() == subsequent_checksum.hexdigest()
+
 def test_debug_mode():
     from language_tool_python.server import DEBUG_MODE
     assert DEBUG_MODE is False


### PR DESCRIPTION
### Changes
* Implements optional feature that enables new spellings to not persist past the current server session. This makes it such that the global spellings file before server start and after server exit are identical.
* Adds unit test.
* Removes unreliable `__del__` function (that is never actually called in my testing) in favor of context manager.