### PR TITLE
Register New Spellings After Server Start

### DIFF
--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -36,9 +36,6 @@ class LanguageTool:
     def __init__(self, language=None, motherTongue=None, remote_server=None, newSpellings=None, new_spellings_persist=True):
         self._new_spellings = None
         self._new_spellings_persist = new_spellings_persist
-        if newSpellings:
-            self._new_spellings = newSpellings
-            self._register_spellings(self._new_spellings)
         if remote_server is not None:
             self._remote = True
             self._url = parse_url(remote_server)
@@ -51,6 +48,9 @@ class LanguageTool:
                 language = get_locale_language()
             except ValueError:
                 language = FAILSAFE_LANGUAGE
+        if newSpellings:
+            self._new_spellings = newSpellings
+            self._register_spellings(self._new_spellings)
         self._language = LanguageTag(language, self._get_languages())
         self.motherTongue = motherTongue
         self.disabled_rules = set()


### PR DESCRIPTION
### Changes

Optional new spellings are now registered after the server is started. This fixes a bug where if LT isn't downloaded yet, new spellings won't be able to be registered, due to spellings file being nonexistent.

Requires #37 for tests to pass.

### Examples

[Before fix](https://app.circleci.com/pipelines/github/aokellermann/markdown_lt/30/workflows/e01c503a-2dd3-4e2c-948b-c0462e6593dc/jobs/34):

![image](https://user-images.githubusercontent.com/26678747/107884720-91946900-6ec4-11eb-875d-d5de9de012ca.png)

After fix:
![image](https://user-images.githubusercontent.com/26678747/107884750-af61ce00-6ec4-11eb-8b23-2cb2dc0c222d.png)

