### PR TITLE
Fix Unicode

### DIFF
--- a/language_tool_python/match.py
+++ b/language_tool_python/match.py
@@ -1,3 +1,4 @@
+import unicodedata
 from collections import OrderedDict
 from functools import total_ordering
 
@@ -56,6 +57,8 @@ class Match:
         attrib['replacements'] = [r['value'] for r in attrib['replacements']]
         # Rename error length.
         attrib['errorLength'] = attrib['length']
+        # Normalize unicode
+        attrib['message'] = unicodedata.normalize("NFKC", attrib['message'])
         # Store objects on self.
         for k, v in attrib.items():
             setattr(self, k, v)


### PR DESCRIPTION
### Changes

Normalizes match message so tests now pass.

Note the `\xa0` byte in [this failed test](https://github.com/jxmorris12/language_tool_python/pull/36/checks?check_run_id=1898575802).