### PR TITLE
Add support for 'auto' language type which is available from LanguageTool API

### DIFF
--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -68,6 +68,7 @@ class LanguageTool:
         self.disabled_categories = set()
         self.enabled_categories = set()
         self.enabled_rules_only = False
+        self.preferred_variants = set()
         self._instances[id(self)] = self
 
     def __enter__(self):
@@ -134,6 +135,8 @@ class LanguageTool:
             params['disabledCategories'] = ','.join(self.disabled_categories)
         if self.enabled_categories:
             params['enabledCategories'] = ','.join(self.enabled_categories)
+        if self.preferred_variants:
+            params['preferredVariants'] = ','.join(self.preferred_variants)
         # return urllib.parse.urlencode(params).encode()
         return params
 
@@ -187,6 +190,7 @@ class LanguageTool:
         for e in self._query_server(url, num_tries=1):
             languages.add(e.get('code'))
             languages.add(e.get('longCode'))
+        languages.add("auto")
         return languages
 
     def _start_server_if_needed(self):

--- a/tests/test_major_functionality.py
+++ b/tests/test_major_functionality.py
@@ -8,7 +8,7 @@ def test_langtool_load():
 def test_langtool_languages():
 	import language_tool_python
 	lang_tool = language_tool_python.LanguageTool("en-US")
-	assert lang_tool._get_languages() == {'es-AR', 'ta-IN', 'en-CA', 'da', 'eo', 'pt-AO', 'de', 'gl', 'ru-RU', 'de-DE', 'en', 'br', 'en-ZA', 'pt-MZ', 'ast-ES', 'sk-SK', 'en-AU', 'ta', 'ga', 'be', 'pl', 'tl-PH', 'sl', 'ar', 'es', 'sl-SI', 'en-NZ', 'el', 'el-GR', 'ru', 'zh-CN', 'en-GB', 'be-BY', 'pl-PL', 'km-KH', 'pt', 'uk-UA', 'ca', 'de-DE-x-simple-language', 'ro', 'ca-ES', 'de-CH', 'ja-JP', 'tl', 'pt-PT', 'gl-ES', 'pt-BR', 'km', 'ga-IE', 'ja', 'sv', 'sk', 'en-US', 'de-AT', 'ca-ES-valencia', 'uk', 'it', 'zh', 'br-FR', 'da-DK', 'ast', 'fr', 'fa', 'nl', 'ro-RO', 'nl-BE'}
+	assert lang_tool._get_languages() == {'es-AR', 'ta-IN', 'en-CA', 'da', 'eo', 'pt-AO', 'de', 'gl', 'ru-RU', 'de-DE', 'en', 'br', 'en-ZA', 'pt-MZ', 'ast-ES', 'sk-SK', 'en-AU', 'ta', 'ga', 'be', 'pl', 'tl-PH', 'sl', 'ar', 'es', 'sl-SI', 'en-NZ', 'el', 'el-GR', 'ru', 'zh-CN', 'en-GB', 'be-BY', 'pl-PL', 'km-KH', 'pt', 'uk-UA', 'ca', 'de-DE-x-simple-language', 'ro', 'ca-ES', 'de-CH', 'ja-JP', 'tl', 'pt-PT', 'gl-ES', 'pt-BR', 'km', 'ga-IE', 'ja', 'sv', 'sk', 'en-US', 'de-AT', 'ca-ES-valencia', 'uk', 'it', 'zh', 'br-FR', 'da-DK', 'ast', 'fr', 'fa', 'nl', 'ro-RO', 'nl-BE', 'auto'}
 
 def test_match():
 	import language_tool_python


### PR DESCRIPTION
I noticed when looking at the the LanguageTool API documentation that this library doesn't support using the `auto` language code in conjunction with `preferredVariants` (see [here](https://languagetool.org/http-api/swagger-ui/#!/default/post_check)).

Two changes were required here to support this:

1. Since the `auto` language code isn't returned by the `GET /languages` [route](https://languagetool.org/http-api/swagger-ui/#!/default/get_languages) the `LanguageTag._normalize` validation fails. To get around this I just add the 'auto' tag in the `_get_languages` function (and updated the `test_langtool_languages` test accordingly).
2. If we are using `auto` we can supply `preferredVariants` (e.g. en-US or de-DE). I just went ahead and added this to the `LanguageTool` object which can be set if required like:

```
tool = LanguageTool('auto')
tool.preferred_variants = ['en-US', 'de-DE']
```

Happy to make any styling changes or add any tests if required.

Cheers!