### PR TITLE
Bump languagetool version to 6.6.

### DIFF
--- a/language_tool_python/download_lt.py
+++ b/language_tool_python/download_lt.py
@@ -27,7 +27,7 @@ logger.setLevel(logging.INFO)
 BASE_URL = os.environ.get('LTP_DOWNLOAD_HOST', 'https://www.languagetool.org/download/')
 FILENAME = 'LanguageTool-{version}.zip'
 
-LTP_DOWNLOAD_VERSION = '6.5'
+LTP_DOWNLOAD_VERSION = '6.6'
 
 JAVA_VERSION_REGEX = re.compile(
     r'^(?:java|openjdk) version "(?P<major1>\d+)(|\.(?P<major2>\d+)\.[^"]+)"',
@@ -74,7 +74,7 @@ def confirm_java_compatibility() -> bool:
     :return: True if the Java version is compatible.
     :rtype: bool
     """
-    
+
     java_path = which('java')
     if not java_path:
         raise ModuleNotFoundError(
@@ -109,7 +109,7 @@ def get_common_prefix(z: zipfile.ZipFile) -> Optional[str]:
     :return: The common prefix of all file names in the zip archive, or None if there is no common prefix.
     :rtype: Optional[str]
     """
-    
+
     name_list = z.namelist()
     if name_list and all(n.startswith(name_list[0]) for n in name_list[1:]):
         return name_list[0]
@@ -152,7 +152,7 @@ def unzip_file(temp_file: str, directory_to_extract_to: str) -> None:
     :param directory_to_extract_to: The directory where the contents of the zip file will be extracted.
     :type directory_to_extract_to: str
     """
-    
+
     logger.info(f'Unzipping {temp_file.name} to {directory_to_extract_to}.')
     with zipfile.ZipFile(temp_file.name, 'r') as zip_ref:
         zip_ref.extractall(directory_to_extract_to)
@@ -184,11 +184,11 @@ def download_lt(language_tool_version: Optional[str] = LTP_DOWNLOAD_VERSION) -> 
     """
     Downloads and extracts the specified version of LanguageTool.
     This function checks for Java compatibility, creates the necessary download
-    directory if it does not exist, and downloads the specified version of 
+    directory if it does not exist, and downloads the specified version of
     LanguageTool if it is not already present.
-    
-    :param language_tool_version: The version of LanguageTool to download. If not 
-                                  specified, the default version defined by 
+
+    :param language_tool_version: The version of LanguageTool to download. If not
+                                  specified, the default version defined by
                                   LTP_DOWNLOAD_VERSION is used.
     :type language_tool_version: Optional[str]
     :raises AssertionError: If the download folder is not a directory.


### PR DESCRIPTION
languagetool 6.5 doesn't work with the current jdk in arch linux (see https://forum.languagetool.org/t/error-recently-arch-linux-upgraded-jdk-openjdk-to-v-24-u36-1/11162/3 for reference). Version 6.6 does, so bumped it.