### PR TITLE
fix: as a lib we should not configure the root logger

### DIFF
--- a/language_tool_python/download_lt.py
+++ b/language_tool_python/download_lt.py
@@ -21,7 +21,6 @@ from .utils import (
 )
 
 # Create logger for this file.
-logging.basicConfig(format='%(message)s')
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
While setting the basicConfig value to the root logger it creates a new StreamHandler and adds it to the root logger.
When an app that uses the lib language_tool_python also import the logging lib, its own root logger get affected by this line and logs are printed two times.