### PR TITLE
fix: removed stdout/stderr reading, making it easier to run and close LT

### DIFF
--- a/tests/test_major_functionality.py
+++ b/tests/test_major_functionality.py
@@ -6,7 +6,7 @@ import pytest
 
 from language_tool_python.exceptions import LanguageToolError, RateLimitError
 
-# THESE TESTS ARE SUPPOSED TO BE RUN WITH 6.7-SNAPSHOT VERSION OF LT SERVER
+# THESE TESTS ARE SUPPOSED TO BE RUN WITH 6.8-SNAPSHOT VERSION OF LT SERVER
 
 
 def test_langtool_load():
@@ -101,6 +101,7 @@ def test_process_starts_and_stops_in_context_manager():
         proc: subprocess.Popen = tool._server
         # Make sure process is running before killing language tool object.
         assert proc.poll() is None, "tool._server not running after creation"
+    time.sleep(0.5)  # Give some time for process to stop after context manager exit.
     # Make sure process stopped after close() was called.
     assert proc.poll() is not None, "tool._server should stop running after deletion"
 
@@ -115,6 +116,7 @@ def test_process_starts_and_stops_on_close():
     tool.close()  # Explicitly close() object so process stops before garbage collection.
     del tool
     # Make sure process stopped after close() was called.
+    time.sleep(0.5)  # Give some time for process to stop after close() call.
     assert proc.poll() is not None, "tool._server should stop running after deletion"
     # remember --> if poll is None: # p.subprocess is alive
 


### PR DESCRIPTION
# fix: removed stdout/stderr reading, making it easier to run and close LT

## Why the pull request was made
Removal of all stdout and stderr handling in server, which could lead to deadlocks and prevent LT from closing properly.

## Summary of changes
- Removed stdout/stderr handling (set to None)
- Removed linked thread and his management
- Edited the way to check if the LT server is running
- Updated tests to wait properly server's closing

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Ran pytest (locally).

## Resources
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [x] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters and tests.
