### PR TITLE
docs: added auto-genereted doc (sphinx), corrected the way of writing class attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Current LanguageTool version: **6.8-SNAPSHOT**
 
-This is a Python wrapper for [LanguageTool](https://languagetool.org). LanguageTool is open-source grammar tool, also known as the spellchecker for OpenOffice. This library allows you to make to detect grammar errors and spelling mistakes through a Python script or through a command-line interface.
+This is a Python wrapper for [LanguageTool](https://languagetool.org). LanguageTool is an open-source grammar tool, also known as the spellchecker for OpenOffice. This library allows you to detect grammar errors and spelling mistakes through a Python script or through a command-line interface.
 
 ## Local and Remote Servers
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,36 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "language_tool_python"
+copyright = "2025, jxmorris12"
+author = "jxmorris12"
+release = "2.9.5"  # Keep in sync with pyproject.toml
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx.ext.autodoc", "sphinx_design"]
+
+templates_path = ["_templates"]
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "furo"
+html_static_path = ["_static"]
+
+# -- Options for autodoc -----------------------------------------------------
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": True,
+    "private-members": True,
+    "show-inheritance": True,
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,21 @@
+.. language_tool_python documentation master file, created by
+   sphinx-quickstart on Wed Nov 12 18:23:43 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+language_tool_python documentation
+==================================
+
+`language_tool_python` is a Python wrapper for `LanguageTool <https://languagetool.org>`_. LanguageTool is an open-source grammar tool, also known as the spellchecker for OpenOffice. This library allows you to detect grammar errors and spelling mistakes through a Python script or through a command-line interface.
+
+In this documentation
+---------------------
+
+* :doc:`References <./references/language_tool_python>`
+* :doc:`Modules <./references/modules>`
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+

--- a/docs/source/references/language_tool_python.rst
+++ b/docs/source/references/language_tool_python.rst
@@ -1,0 +1,69 @@
+language\_tool\_python package
+==============================
+
+Submodules
+----------
+
+language\_tool\_python.config\_file module
+------------------------------------------
+
+.. automodule:: language_tool_python.config_file
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+language\_tool\_python.download\_lt module
+------------------------------------------
+
+.. automodule:: language_tool_python.download_lt
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+language\_tool\_python.exceptions module
+----------------------------------------
+
+.. automodule:: language_tool_python.exceptions
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+language\_tool\_python.language\_tag module
+-------------------------------------------
+
+.. automodule:: language_tool_python.language_tag
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+language\_tool\_python.match module
+-----------------------------------
+
+.. automodule:: language_tool_python.match
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+language\_tool\_python.server module
+------------------------------------
+
+.. automodule:: language_tool_python.server
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+language\_tool\_python.utils module
+-----------------------------------
+
+.. automodule:: language_tool_python.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: language_tool_python
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/references/modules.rst
+++ b/docs/source/references/modules.rst
@@ -1,0 +1,7 @@
+language_tool_python
+====================
+
+.. toctree::
+   :maxdepth: 4
+
+   language_tool_python

--- a/language_tool_python/__main__.py
+++ b/language_tool_python/__main__.py
@@ -121,8 +121,9 @@ class RulesAction(argparse.Action):
     namespace when the action is triggered. It updates the attribute specified
     by 'self.dest' with the provided values.
 
-    Attributes:
-        dest (str): the destination attribute to update
+    .. attribute:: dest
+        :type: str
+        The destination attribute to update.
     """
 
     def __call__(

--- a/language_tool_python/config_file.py
+++ b/language_tool_python/config_file.py
@@ -18,19 +18,18 @@ class OptionSpec:
     This class defines the structure and behavior of a configuration option,
     including its type constraints, encoding mechanism, and optional validation.
 
-    Attributes:
-        py_types (Union[type, tuple[type, ...]]): The Python type(s) that this option accepts.
-        encoder (Callable[[Any], str]): A callable that converts the option value to its string representation.
-        validator (Optional[Callable[[Any], None]]): An optional callable that validates the option value.
-
-    .. note::
     This class is frozen (immutable) to ensure configuration specifications
     remain constant throughout the application lifecycle.
     """
 
     py_types: Union[type, tuple[type, ...]]
+    """The Python type(s) that this option accepts."""
+
     encoder: Callable[[Any], str]
+    """A callable that converts the option value to its string representation."""
+
     validator: Optional[Callable[[Any], None]] = None
+    """An optional validator function for the option value."""
 
 
 def _bool_encoder(v: Any) -> str:
@@ -201,14 +200,13 @@ class LanguageToolConfig:
 
     :param config: Dictionary containing configuration keys and values.
     :type config: Dict[str, Any]
-
-    Attributes:
-        config (Dict[str, Any]): Dictionary containing configuration keys and values.
-        path (str): Path to the temporary file storing the configuration.
     """
 
     config: Dict[str, Any]
+    """Dictionary containing configuration keys and values."""
+
     path: str
+    """Path to the temporary file storing the configuration."""
 
     def __init__(self, config: Dict[str, Any]):
         """

--- a/language_tool_python/download_lt.py
+++ b/language_tool_python/download_lt.py
@@ -117,8 +117,8 @@ def confirm_java_compatibility(
         )
     )
 
-    # Some installs of java show the version number like `14.0.1`
-    # and others show `1.14.0.1`
+    # Some installs of java show the version number like '14.0.1'
+    # and others show '1.14.0.1'
     # (with a leading 1). We want to support both.
     # (See softwareengineering.stackexchange.com/questions/175075/why-is-java-version-1-x-referred-to-as-java-x)
     if is_old_version:

--- a/language_tool_python/exceptions.py
+++ b/language_tool_python/exceptions.py
@@ -11,7 +11,7 @@ class LanguageToolError(Exception):
 class ServerError(LanguageToolError):
     """
     Exception raised for errors that occur when interacting with the LanguageTool server.
-    This exception is a subclass of `LanguageToolError` and is used to indicate
+    This exception is a subclass of ``LanguageToolError`` and is used to indicate
     issues such as server startup failures.
     """
 
@@ -21,7 +21,7 @@ class ServerError(LanguageToolError):
 class JavaError(LanguageToolError):
     """
     Exception raised for errors related to the Java backend of LanguageTool.
-    This exception is a subclass of `LanguageToolError` and is used to indicate
+    This exception is a subclass of ``LanguageToolError`` and is used to indicate
     issues that occur when interacting with Java, such as Java not being found.
     """
 
@@ -42,7 +42,7 @@ class PathError(LanguageToolError):
 class RateLimitError(LanguageToolError):
     """
     Exception raised for errors related to rate limiting in the LanguageTool server.
-    This exception is a subclass of `LanguageToolError` and is used to indicate
+    This exception is a subclass of ``LanguageToolError`` and is used to indicate
     issues such as exceeding the allowed number of requests to the public API without a key.
     """
 

--- a/language_tool_python/language_tag.py
+++ b/language_tool_python/language_tag.py
@@ -14,15 +14,19 @@ class LanguageTag:
     :type tag: str
     :param languages: An iterable of supported language tags.
     :type languages: Iterable[str]
-
-    Attributes:
-        tag (str): The language tag to be normalized.
-        languages (Iterable[str]): An iterable of supported language tags.
-        normalized_tag (str): The normalized language tag.
-        _LANGUAGE_RE (re.Pattern): A regular expression to match language tags.
     """
 
+    tag: str
+    """The language tag to be normalized."""
+
+    languages: Iterable[str]
+    """An iterable of supported language tags."""
+
+    normalized_tag: str
+    """The normalized language tag."""
+
     _LANGUAGE_RE = re.compile(r"^([a-z]{2,3})(?:[_-]([a-z]{2}))?$", re.I)
+    """A regular expression to match language tags."""
 
     def __init__(self, tag: str, languages: Iterable[str]) -> None:
         """

--- a/language_tool_python/match.py
+++ b/language_tool_python/match.py
@@ -105,54 +105,69 @@ class Match:
     Represents a match object that contains information about a language rule violation.
 
     :param attrib: A dictionary containing various attributes for the match.
-                       The dictionary is expected to have the following keys:
+                    The dictionary is expected to have the following keys:
 
-                       - 'rule': A dictionary with keys 'category' (which has an 'id') and 'id', 'issueType'.
-
-                       - 'context': A dictionary with keys 'offset' and 'text'.
-
-                       - 'replacements': A list of dictionaries, each containing a 'value'.
-
-                       - 'length': The length of the error.
-
-                       - 'message': The message describing the error.
+                        - ``rule`` (*Dict[str, Any]*): A dictionary with keys ``category`` (which has an ``id``) and ``id``, ``issueType``.
+                        - ``context`` (*Dict[str, Any]*): A dictionary with keys ``offset`` and ``text``.
+                        - ``replacements`` (*List[Dict[str, str]]*): A list of dictionaries, each containing a ``value``.
+                        - ``length`` (*int*): The length of the error.
+                        - ``message`` (*str*): The message describing the error.
     :type attrib: Dict[str, Any]
     :param text: The original text in which the error occurred (the whole text, not just the context).
     :type text: str
 
-    Attributes:
-        PREVIOUS_MATCHES_TEXT (Optional[str]): The text of the previous match object.
-        FOUR_BYTES_POSITIONS (Optional[List[int]]): The positions of 4-byte encoded characters in the text, registered by the previous match object (kept for optimization purposes if the text is the same).
-        ruleId (str): The ID of the rule that was violated.
-        message (str): The message describing the error.
-        replacements (list): A list of suggested replacements for the error.
-        offsetInContext (int): The offset of the error in the context.
-        context (str): The context in which the error occurred.
-        offset (int): The offset of the error.
-        errorLength (int): The length of the error.
-        category (str): The category of the rule that was violated.
-        ruleIssueType (str): The issue type of the rule that was violated.
+    Example of a match object received from the LanguageTool API :
 
-    Exemple of a match object received from the LanguageTool API :
+    .. code-block:: python
 
-    ```
-    {
-        'message': 'Possible spelling mistake found.',
-        'shortMessage': 'Spelling mistake',
-        'replacements': [{'value': 'newt'}, {'value': 'not'}, {'value': 'new', 'shortDescription': 'having just been made'}, {'value': 'news'}, {'value': 'foot', 'shortDescription': 'singular'}, {'value': 'root', 'shortDescription': 'underground organ of a plant'}, {'value': 'boot'}, {'value': 'noon'}, {'value': 'loot', 'shortDescription': 'plunder'}, {'value': 'moot'}, {'value': 'Root'}, {'value': 'soot', 'shortDescription': 'carbon black'}, {'value': 'newts'}, {'value': 'nook'}, {'value': 'Lieut'}, {'value': 'coot'}, {'value': 'hoot'}, {'value': 'toot'}, {'value': 'snoot'}, {'value': 'neut'}, {'value': 'nowt'}, {'value': 'Noor'}, {'value': 'noob'}],
-        'offset': 8,
-        'length': 4,
-        'context': {'text': 'This is noot okay. ', 'offset': 8, 'length': 4}, 'sentence': 'This is noot okay.',
-        'type': {'typeName': 'Other'},
-        'rule': {'id': 'MORFOLOGIK_RULE_EN_US', 'description': 'Possible spelling mistake', 'issueType': 'misspelling', 'category': {'id': 'TYPOS', 'name': 'Possible Typo'}},
-        'ignoreForIncompleteSentence': False,
-        'contextForSureMatch': 0
-    }
-    ```
+        {
+            'message': 'Possible spelling mistake found.',
+            'shortMessage': 'Spelling mistake',
+            'replacements': [{'value': 'newt'}, {'value': 'not'}, {'value': 'new', 'shortDescription': 'having just been made'}, {'value': 'news'}, {'value': 'foot', 'shortDescription': 'singular'}, {'value': 'root', 'shortDescription': 'underground organ of a plant'}, {'value': 'boot'}, {'value': 'noon'}, {'value': 'loot', 'shortDescription': 'plunder'}, {'value': 'moot'}, {'value': 'Root'}, {'value': 'soot', 'shortDescription': 'carbon black'}, {'value': 'newts'}, {'value': 'nook'}, {'value': 'Lieut'}, {'value': 'coot'}, {'value': 'hoot'}, {'value': 'toot'}, {'value': 'snoot'}, {'value': 'neut'}, {'value': 'nowt'}, {'value': 'Noor'}, {'value': 'noob'}],
+            'offset': 8,
+            'length': 4,
+            'context': {'text': 'This is noot okay. ', 'offset': 8, 'length': 4}, 'sentence': 'This is noot okay.',
+            'type': {'typeName': 'Other'},
+            'rule': {'id': 'MORFOLOGIK_RULE_EN_US', 'description': 'Possible spelling mistake', 'issueType': 'misspelling', 'category': {'id': 'TYPOS', 'name': 'Possible Typo'}},
+            'ignoreForIncompleteSentence': False,
+            'contextForSureMatch': 0
+        }
+
     """
 
     PREVIOUS_MATCHES_TEXT: Optional[str] = None
+    """The text of the previous match object."""
+
     FOUR_BYTES_POSITIONS: Optional[List[int]] = None
+    """The positions of 4-byte encoded characters in the text, registered by the previous match object
+    (kept for optimization purposes if the text is the same)."""
+
+    ruleId: str
+    """The ID of the rule that was violated."""
+
+    message: str
+    """The message describing the error."""
+
+    replacements: List[str]
+    """A list of suggested replacements for the error."""
+
+    offsetInContext: int
+    """The offset of the error in the context."""
+
+    context: str
+    """The context in which the error occurred."""
+
+    offset: int
+    """The offset of the error."""
+
+    errorLength: int
+    """The length of the error."""
+
+    category: str
+    """The category of the rule that was violated."""
+
+    ruleIssueType: str
+    """The issue type of the rule that was violated."""
 
     def __init__(self, attrib: Dict[str, Any], text: str) -> None:
         """
@@ -206,7 +221,7 @@ class Match:
             Generate a string representation of the object's attributes in an ordered dictionary format.
 
             This method collects the attributes of the object, ensuring that the order of attributes
-            is preserved as defined by `get_match_ordered_dict()`. Attributes that are not part of the
+            is preserved as defined by ``get_match_ordered_dict()``. Attributes that are not part of the
             ordered dictionary are appended at the end. Attributes starting with an underscore are
             excluded from the representation.
 
@@ -321,7 +336,7 @@ class Match:
         Return an iterator over the attributes of the match object.
 
         This method allows the match object to be iterated over, yielding the
-        values of its attributes in the order defined by `get_match_ordered_dict`.
+        values of its attributes in the order defined by ``get_match_ordered_dict()``.
 
         :return: An iterator over the attribute values of the match object.
         :rtype: Iterator[Any]
@@ -333,7 +348,7 @@ class Match:
         Set an attribute on the instance.
 
         This method overrides the default behavior of setting an attribute.
-        It attempts to transform the value using a function from `get_match_ordered_dict()`
+        It attempts to transform the value using a function from ``get_match_ordered_dict()``
         based on the provided key. If the key is not found in the dictionary, the attribute
         is not set.
 
@@ -341,7 +356,6 @@ class Match:
         :type key: str
         :param value: The value to set the attribute to.
         :type value: Any
-        :raises KeyError: If the key is not found in the dictionary returned by `get_match_ordered_dict()`.
         """
         try:
             value = get_match_ordered_dict()[key](value)
@@ -355,7 +369,7 @@ class Match:
 
         This method is called when an attribute lookup has not found the attribute in the usual places
         (i.e., it is not an instance attribute nor is it found in the class tree for self). This method
-        checks if the attribute name is in the ordered dictionary returned by `get_match_ordered_dict()`.
+        checks if the attribute name is in the ordered dictionary returned by ``get_match_ordered_dict()``.
         If the attribute name is not found, it raises an AttributeError.
 
         :param name: The name of the attribute being accessed.

--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -78,30 +78,70 @@ class LanguageTool:
     :type config: Optional[str]
     :param language_tool_download_version: The version of LanguageTool to download if needed.
     :type language_tool_download_version: Optional[str]
-
-    Attributes:
-        _AVAILABLE_PORTS (List[int]): A list of available ports for the server, shuffled randomly.
-        _TIMEOUT (int): The timeout for server requests.
-        _remote (bool): A flag to indicate if the server is remote.
-        _port (int): The port number to use for the server.
-        _server (subprocess.Popen): The server process.
-        language_tool_download_version (str): The version of LanguageTool to download.
-        _new_spellings (List[str]): A list of new spellings to register.
-        _new_spellings_persist (bool): A flag to indicate if new spellings should persist.
-        _host (str): The host to use for the server.
-        config (LanguageToolConfig): The configuration to use for the server.
-        _url (str): The URL of the server if remote.
-        motherTongue (str): The user's mother tongue (used in requests to the server).
-        disabled_rules (Set[str]): A set of disabled rules (used in requests to the server).
-        enabled_rules (Set[str]): A set of enabled rules (used in requests to the server).
-        disabled_categories (Set[str]): A set of disabled categories (used in requests to the server).
-        enabled_categories (Set[str]): A set of enabled categories (used in requests to the server).
-        enabled_rules_only (bool): A flag to indicate if only enabled rules should be used (used in requests to the server).
-        preferred_variants (Set[str]): A set of preferred variants (used in requests to the server).
-        picky (bool): A flag to indicate if the tool should be picky (used in requests to the server).
-        language (str): The language to use (used in requests to the server and in other methods).
-        _spell_checking_categories (Set[str]): A set of spell-checking categories.
     """
+
+    _AVAILABLE_PORTS: List[int]
+    """A list of available ports for the server, shuffled randomly."""
+
+    _TIMEOUT: int
+    """The timeout for server requests."""
+
+    _remote: bool
+    """A flag to indicate if the server is remote."""
+
+    _port: int
+    """The port number to use for the server."""
+
+    _server: subprocess.Popen
+    """The server process."""
+
+    _language_tool_download_version: str
+    """The version of LanguageTool to download."""
+
+    _new_spellings: Optional[List[str]]
+    """A list of new spellings to register."""
+
+    _new_spellings_persist: bool
+    """A flag to indicate if new spellings should persist."""
+
+    _host: str
+    """The host to use for the server."""
+
+    config: Optional[LanguageToolConfig]
+    """The configuration to use for the server."""
+
+    _url: str
+    """The URL of the server if remote."""
+
+    motherTongue: Optional[str]
+    """The user's mother tongue (used in requests to the server)."""
+
+    disabled_rules: Set[str]
+    """A set of disabled rules (used in requests to the server)."""
+
+    enabled_rules: Set[str]
+    """A set of enabled rules (used in requests to the server)."""
+
+    enabled_rules_only: bool
+    """A flag to indicate if only enabled rules should be used (used in requests to the server)."""
+
+    preferred_variants: Set[str]
+    """A set of preferred variants (used in requests to the server)."""
+
+    picky: bool
+    """A flag to indicate if the tool should be picky (used in requests to the server)."""
+
+    language: LanguageTag
+    """The language to use (used in requests to the server and in other methods)."""
+
+    _spell_checking_categories: Set[str]
+    """A set of spell-checking categories."""
+
+    disabled_categories: Set[str]
+    """A set of disabled categories (used in requests to the server)."""
+
+    enabled_categories: Set[str]
+    """A set of enabled categories (used in requests to the server)."""
 
     def __init__(
         self,
@@ -163,7 +203,7 @@ class LanguageTool:
         Enter the runtime context related to this object.
 
         This method is called when execution flow enters the context of the
-        `with` statement using this object. It returns the object itself.
+        ``with`` statement using this object. It returns the object itself.
 
         :return: The object itself.
         :rtype: LanguageTool
@@ -199,7 +239,7 @@ class LanguageTool:
         """
         Destructor method that ensures the server is properly closed.
         This method is called when the instance is about to be destroyed. It
-        ensures that the `close` method is called to release any resources
+        ensures that the ``close`` method is called to release any resources
         or perform any necessary cleanup.
         """
         if self._server_is_alive():
@@ -222,7 +262,7 @@ class LanguageTool:
         This method performs the following actions:
         1. Checks if the server is alive and terminates it if necessary.
         2. If new spellings are not set to persist and there are new spellings,
-           it unregisters the spellings and clears the list of new spellings.
+        it unregisters the spellings and clears the list of new spellings.
         """
         if self._server_is_alive():
             self._terminate_server()
@@ -359,8 +399,8 @@ class LanguageTool:
     def enable_spellchecking(self) -> None:
         """
         Enable spellchecking by removing spell checking categories from the disabled categories set.
-        This method updates the `disabled_categories` attribute by removing any categories that are
-        related to spell checking, which are defined in the `_spell_checking_categories` attribute.
+        This method updates the ``disabled_categories`` attribute by removing any categories that are
+        related to spell checking, which are defined in the ``_spell_checking_categories`` attribute.
         """
         self.disabled_categories.difference_update(self._spell_checking_categories)
 
@@ -425,7 +465,7 @@ class LanguageTool:
         """
         Unregister new spellings from the spelling file.
         This method reads the current spellings from the spelling file, removes any
-        spellings that are present in the `_new_spellings` attribute, and writes the
+        spellings that are present in the ``_new_spellings`` attribute, and writes the
         updated list back to the file.
         """
         spelling_file_path = self._get_valid_spelling_file_path()
@@ -672,7 +712,7 @@ class LanguageTool:
 class LanguageToolPublicAPI(LanguageTool):
     """
     A class to interact with the public LanguageTool API.
-    This class extends the `LanguageTool` class and initializes it with the
+    This class extends the ``LanguageTool`` class and initializes it with the
     remote server set to the public LanguageTool API endpoint.
 
     :param args: Positional arguments passed to the parent class initializer.

--- a/language_tool_python/utils.py
+++ b/language_tool_python/utils.py
@@ -66,11 +66,11 @@ def classify_matches(matches: List[Match]) -> TextStatus:
     Classify the matches (result of a check on a text) into one of three categories:
     CORRECT, FAULTY, or GARBAGE.
     This function checks the status of the matches and returns a corresponding
-    `TextStatus` value.
+    ``TextStatus`` value.
 
     :param matches: A list of Match objects to be classified.
     :type matches: List[Match]
-    :return: The classification of the matches as a `TextStatus` value.
+    :return: The classification of the matches as a ``TextStatus`` value.
     :rtype: TextStatus
     """
     if not len(matches):
@@ -116,8 +116,8 @@ def get_language_tool_download_path() -> str:
     """
     Get the download path for LanguageTool.
     This function retrieves the download path for LanguageTool from the environment variable
-    specified by `LTP_PATH_ENV_VAR`. If the environment variable is not set, it defaults to
-    a path in the user's home directory under `.cache/language_tool_python`.
+    specified by ``LTP_PATH_ENV_VAR``. If the environment variable is not set, it defaults to
+    a path in the user's home directory under ``.cache/language_tool_python``.
 
     :return: The download path for LanguageTool.
     :rtype: str
@@ -241,8 +241,8 @@ def get_locale_language() -> str:
     """
     Get the current locale language.
     This function retrieves the current locale language setting of the system.
-    It first attempts to get the locale using `locale.getlocale()`. If that fails,
-    it falls back to using `locale.getdefaultlocale()`.
+    It first attempts to get the locale using ``locale.getlocale()``. If that fails,
+    it falls back to using ``locale.getdefaultlocale()``.
 
     :return: The language code of the current locale.
     :rtype: str
@@ -260,11 +260,11 @@ def kill_process_force(
     This function attempts to kill a process specified either by its PID or by a psutil.Process object.
     If the process has any child processes, they will be killed first.
 
-    :param pid: The process ID of the process to be killed. Either `pid` or `proc` must be provided.
+    :param pid: The process ID of the process to be killed. Either ``pid`` or ``proc`` must be provided.
     :type pid: Optional[int]
-    :param proc: A psutil.Process object representing the process to be killed. Either `pid` or `proc` must be provided.
+    :param proc: A psutil.Process object representing the process to be killed. Either ``pid`` or ``proc`` must be provided.
     :type proc: Optional[psutil.Process]
-    :raises ValueError: If neither `pid` nor `proc` is provided.
+    :raises ValueError: If neither ``pid`` nor ``proc`` is provided.
     """
     if not any([pid, proc]):
         raise ValueError("Must pass either pid or proc")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,13 +34,20 @@ dependencies = [
     "toml"
 ]
 
-[project.optional-dependencies]
-dev = [
+[dependency-groups]
+tests = [
     "pytest",
     "pytest-xdist",
     "pytest-cov",
     "pytest-runner"
 ]
+
+docs = [
+  "furo",
+  "sphinx",
+  "sphinx-design",
+]
+
 
 [project.scripts]
 language_tool_python = "language_tool_python.__main__:main"


### PR DESCRIPTION
# docs: added auto-genereted doc (sphinx), corrected the way of writing class attributes

## Why the pull request was made
To make the documentation fully compliant with reStructuredText, and enable automatic generation of the documentation.

## Summary of changes
- Edited doc to fit in reStructuredText rules
- Added auto generated doc (sphinx)
- Edited optional dependencies (from opt to groups)

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied local tests.

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters and tests.
