### PR TITLE
fix (download_it): patch version comparison bug

### DIFF
--- a/language_tool_python/download_lt.py
+++ b/language_tool_python/download_lt.py
@@ -13,6 +13,7 @@ from urllib.parse import urljoin
 
 import requests
 import tqdm
+from packaging.version import Version
 
 from .exceptions import PathError
 from .utils import (
@@ -109,7 +110,7 @@ def confirm_java_compatibility(
     is_old_version = language_tool_version != "latest" and (
         (
             re.match(r"^\d+\.\d+$", language_tool_version)
-            and language_tool_version < "6.6"
+            and Version(language_tool_version) < Version("6.6")
         )
         or (
             re.match(r"^\d{8}$", language_tool_version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ urls = { Repository = "https://github.com/jxmorris12/language_tool_python.git" }
 dependencies = [
     "requests",
     "tqdm",
+    "packaging",
     "psutil",
     "toml"
 ]
@@ -81,4 +82,4 @@ warn_unreachable = true
 no_implicit_optional = true
 show_error_codes = true
 pretty = true
-disable_error_code = ["import-untyped"]
+disable_error_code = ["import-not-found", "import-untyped"]


### PR DESCRIPTION
# fix (download_it): patch version comparison bug

## Why the pull request was made
Fix a bug in LT version comparison. When LT upgrades to version "10.", comparisons will still work.

## Summary of changes
- Comparison of LT versions with an appropriate class.
- Added packaging in dependencies (and added an exception to mypy rules).

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied local tests.

## Resources
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
