### PR TITLE
fix: corrected os version for readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@
 version: 2
 
 build:
-  os: ubuntu-latest
+  os: ubuntu-24.04
   tools:
     python: "3.13"
 


### PR DESCRIPTION
# fix: corrected os version for readthedocs config

## Why the pull request was made
Resolved a bug in readthedocs config to allow doc generation.

## Summary of changes
- fix: corrected os version for readthedocs config

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Not applicable (no change in lib code).

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
