### PR TITLE
fix: from camel case to snake case for some params and attribs (breaking)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,6 +19,7 @@ prune docs/
 prune tests/
 
 exclude .gitignore
+exclude .readthedocs.yaml
 exclude build_and_publish.sh
 exclude CONTRIBUTING.md
 exclude make.bat

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you want to apply a particular suggestion from a `Match`, use `Match.select_r
 >>> tool = language_tool_python.LanguageTool('en-US')
 >>> matches = tool.check(s)
 >>> matches
-[Match({'ruleId': 'MORFOLOGIK_RULE_EN_US', 'message': 'Possible spelling mistake found.', 'replacements': ['BOK', 'OK', 'book', 'box'], 'offsetInContext': 11, 'context': 'There is a bok on the table.', 'offset': 11, 'errorLength': 3, 'category': 'TYPOS', 'ruleIssueType': 'misspelling', 'sentence': 'There is a bok on the table.'})]
+[Match({'rule_id': 'MORFOLOGIK_RULE_EN_US', 'message': 'Possible spelling mistake found.', 'replacements': ['BOK', 'OK', 'book', 'box'], 'offset_in_context': 11, 'context': 'There is a bok on the table.', 'offset': 11, 'error_length': 3, 'category': 'TYPOS', 'rule_issue_type': 'misspelling', 'sentence': 'There is a bok on the table.'})]
 >>> matches[0].select_replacement(2) 
 >>> patched_text = language_tool_python.utils.correct(s, matches)    
 >>> patched_text
@@ -115,9 +115,9 @@ From the interpreter:
 Check out some ``Match`` object attributes:
 
 ```python
->>> matches[0].ruleId, matches[0].replacements # ('EN_A_VS_AN', ['an'])
+>>> matches[0].rule_id, matches[0].replacements # ('EN_A_VS_AN', ['an'])
 ('EN_A_VS_AN', ['an'])
->>> matches[1].ruleId, matches[1].replacements
+>>> matches[1].rule_id, matches[1].replacements
 ('TOT_HE', ['to the'])
 ```
 
@@ -188,7 +188,7 @@ You can run LanguageTool on one host and connect to it from another.  This is us
 >>>
 >>>
 >>> lang_tool.check('helo darknes my old frend')
-[Match({'ruleId': 'UPPERCASE_SENTENCE_START', 'message': 'This sentence does not start with an uppercase letter.', 'replacements': ['Helo'], 'offsetInContext': 0, 'context': 'helo darknes my old frend', 'offset': 0, 'errorLength': 4, 'category': 'CASING', 'ruleIssueType': 'typographical', 'sentence': 'helo darknes my old frend'}), Match({'ruleId': 'MORFOLOGIK_RULE_EN_US', 'message': 'Possible spelling mistake found.', 'replacements': ['darkness', 'darkens', 'darkies'], 'offsetInContext': 5, 'context': 'helo darknes my old frend', 'offset': 5, 'errorLength': 7, 'category': 'TYPOS', 'ruleIssueType': 'misspelling', 'sentence': 'helo darknes my old frend'}), Match({'ruleId': 'MORFOLOGIK_RULE_EN_US', 'message': 'Possible spelling mistake found.', 'replacements': ['friend', 'trend', 'Fred', 'freed', 'Freud', 'Friend', 'fend', 'fiend', 'frond', 'rend', 'fr end'], 'offsetInContext': 20, 'context': 'helo darknes my old frend', 'offset': 20, 'errorLength': 5, 'category': 'TYPOS', 'ruleIssueType': 'misspelling', 'sentence': 'helo darknes my old frend'})]
+[Match({'rule_id': 'UPPERCASE_SENTENCE_START', 'message': 'This sentence does not start with an uppercase letter.', 'replacements': ['Helo'], 'offset_in_Context': 0, 'context': 'helo darknes my old frend', 'offset': 0, 'error_length': 4, 'category': 'CASING', 'rule_issue_type': 'typographical', 'sentence': 'helo darknes my old frend'}), Match({'rule_id': 'MORFOLOGIK_RULE_EN_US', 'message': 'Possible spelling mistake found.', 'replacements': ['darkness', 'darkens', 'darkies'], 'offset_in_context': 5, 'context': 'helo darknes my old frend', 'offset': 5, 'error_length': 7, 'category': 'TYPOS', 'rule_issue_type': 'misspelling', 'sentence': 'helo darknes my old frend'}), Match({'rule_id': 'MORFOLOGIK_RULE_EN_US', 'message': 'Possible spelling mistake found.', 'replacements': ['friend', 'trend', 'Fred', 'freed', 'Freud', 'Friend', 'fend', 'fiend', 'frond', 'rend', 'fr end'], 'offset_in_context': 20, 'context': 'helo darknes my old frend', 'offset': 20, 'error_length': 5, 'category': 'TYPOS', 'rule_issue_type': 'misspelling', 'sentence': 'helo darknes my old frend'})]
 >>>
 ```
 

--- a/language_tool_python/__main__.py
+++ b/language_tool_python/__main__.py
@@ -254,7 +254,7 @@ def main() -> int:
                 remote_server += f":{args.remote_port}"
         with LanguageTool(
             language=args.language,
-            motherTongue=args.mother_tongue,
+            mother_tongue=args.mother_tongue,
             remote_server=remote_server,
         ) as lang_tool:
             try:
@@ -278,7 +278,7 @@ def main() -> int:
                     print(lang_tool.correct(text))
                 else:
                     for match in lang_tool.check(text):
-                        rule_id = match.ruleId
+                        rule_id = match.rule_id
 
                         replacement_text = ", ".join(
                             f"'{word}'" for word in match.replacements

--- a/language_tool_python/match.py
+++ b/language_tool_python/match.py
@@ -29,28 +29,28 @@ def get_match_ordered_dict() -> OrderedDictType[str, type]:
 
     The keys and their corresponding types are:
 
-    - 'ruleId': str
+    - 'rule_id': str
     - 'message': str
     - 'replacements': list
-    - 'offsetInContext': int
+    - 'offset_in_context': int
     - 'context': str
     - 'offset': int
-    - 'errorLength': int
+    - 'error_length': int
     - 'category': str
-    - 'ruleIssueType': str
+    - 'rule_issue_type': str
     - 'sentence': str
     """
     return OrderedDict(
         [
-            ("ruleId", str),
+            ("rule_id", str),
             ("message", str),
             ("replacements", list),
-            ("offsetInContext", int),
+            ("offset_in_context", int),
             ("context", str),
             ("offset", int),
-            ("errorLength", int),
+            ("error_length", int),
             ("category", str),
-            ("ruleIssueType", str),
+            ("rule_issue_type", str),
             ("sentence", str),
         ],
     )
@@ -147,7 +147,7 @@ class Match:
     """The positions of 4-byte encoded characters in the text, registered by the previous match object
     (kept for optimization purposes if the text is the same)."""
 
-    ruleId: str
+    rule_id: str
     """The ID of the rule that was violated."""
 
     message: str
@@ -156,7 +156,7 @@ class Match:
     replacements: List[str]
     """A list of suggested replacements for the error."""
 
-    offsetInContext: int
+    offset_in_context: int
     """The offset of the error in the context."""
 
     context: str
@@ -165,13 +165,13 @@ class Match:
     offset: int
     """The offset of the error."""
 
-    errorLength: int
+    error_length: int
     """The length of the error."""
 
     category: str
     """The category of the rule that was violated."""
 
-    ruleIssueType: str
+    rule_issue_type: str
     """The issue type of the rule that was violated."""
 
     def __init__(self, attrib: Dict[str, Any], text: str) -> None:
@@ -184,16 +184,16 @@ class Match:
 
         # Process rule.
         attrib["category"] = attrib["rule"]["category"]["id"]
-        attrib["ruleId"] = attrib["rule"]["id"]
-        attrib["ruleIssueType"] = attrib["rule"]["issueType"]
+        attrib["rule_id"] = attrib["rule"]["id"]
+        attrib["rule_issue_type"] = attrib["rule"]["issueType"]
         del attrib["rule"]
         # Process context.
-        attrib["offsetInContext"] = attrib["context"]["offset"]
+        attrib["offset_in_context"] = attrib["context"]["offset"]
         attrib["context"] = attrib["context"]["text"]
         # Process replacements.
         attrib["replacements"] = [r["value"] for r in attrib["replacements"]]
         # Rename error length.
-        attrib["errorLength"] = attrib["length"]
+        attrib["error_length"] = attrib["length"]
         # Normalize unicode
         attrib["message"] = unicodedata.normalize("NFKC", attrib["message"])
         # Store objects on self.
@@ -253,17 +253,17 @@ class Match:
         :return: A formatted string describing the match object.
         :rtype: str
         """
-        ruleId = self.ruleId
-        s = f"Offset {self.offset}, length {self.errorLength}, Rule ID: {ruleId}"
+        rule_id = self.rule_id
+        s = f"Offset {self.offset}, length {self.error_length}, Rule ID: {rule_id}"
         if self.message:
             s += f"\nMessage: {self.message}"
         if self.replacements:
             s += f"\nSuggestion: {'; '.join(self.replacements)}"
-        s += f"\n{self.context}\n{' ' * self.offsetInContext + '^' * self.errorLength}"
+        s += f"\n{self.context}\n{' ' * self.offset_in_context + '^' * self.error_length}"
         return s
 
     @property
-    def matchedText(self) -> str:
+    def matched_text(self) -> str:
         """
         Returns the substring from the context that corresponds to the matched text.
 
@@ -271,7 +271,7 @@ class Match:
         :rtype: str
         """
         return self.context[
-            self.offsetInContext : self.offsetInContext + self.errorLength
+            self.offset_in_context : self.offset_in_context + self.error_length
         ]
 
     def get_line_and_column(self, original_text: str) -> Tuple[int, int]:

--- a/language_tool_python/utils.py
+++ b/language_tool_python/utils.py
@@ -104,13 +104,13 @@ def correct(text: str, matches: List[Match]) -> str:
     ltext = list(text)
     matches = [match for match in matches if match.replacements]
     errors = [
-        ltext[match.offset : match.offset + match.errorLength] for match in matches
+        ltext[match.offset : match.offset + match.error_length] for match in matches
     ]
     correct_offset = 0
     for n, match in enumerate(matches):
         frompos, topos = (
             correct_offset + match.offset,
-            correct_offset + match.offset + match.errorLength,
+            correct_offset + match.offset + match.error_length,
         )
         if ltext[frompos:topos] != errors[n]:
             continue

--- a/tests/test_major_functionality.py
+++ b/tests/test_major_functionality.py
@@ -17,31 +17,31 @@ def test_langtool_load():
 
         expected_matches = [
             {
-                "ruleId": "UPPERCASE_SENTENCE_START",
+                "rule_id": "UPPERCASE_SENTENCE_START",
                 "message": "This sentence does not start with an uppercase letter.",
                 "replacements": ["Ai"],
-                "offsetInContext": 0,
+                "offset_in_context": 0,
                 "context": "ain't nothin but a thang",
                 "offset": 0,
-                "errorLength": 2,
+                "error_length": 2,
                 "category": "CASING",
-                "ruleIssueType": "typographical",
+                "rule_issue_type": "typographical",
                 "sentence": "ain't nothin but a thang",
             },
             {
-                "ruleId": "MORFOLOGIK_RULE_EN_US",
+                "rule_id": "MORFOLOGIK_RULE_EN_US",
                 "message": "Possible spelling mistake found.",
                 "replacements": ["nothing", "no thin"],
-                "offsetInContext": 6,
+                "offset_in_context": 6,
                 "context": "ain't nothin but a thang",
                 "offset": 6,
-                "errorLength": 6,
+                "error_length": 6,
                 "category": "TYPOS",
-                "ruleIssueType": "misspelling",
+                "rule_issue_type": "misspelling",
                 "sentence": "ain't nothin but a thang",
             },
             {
-                "ruleId": "MORFOLOGIK_RULE_EN_US",
+                "rule_id": "MORFOLOGIK_RULE_EN_US",
                 "message": "Possible spelling mistake found.",
                 "replacements": [
                     "than",
@@ -60,12 +60,12 @@ def test_langtool_load():
                     "Thanh",
                     "bhang",
                 ],
-                "offsetInContext": 19,
+                "offset_in_context": 19,
                 "context": "ain't nothin but a thang",
                 "offset": 19,
-                "errorLength": 5,
+                "error_length": 5,
                 "category": "TYPOS",
-                "ruleIssueType": "misspelling",
+                "rule_issue_type": "misspelling",
                 "sentence": "ain't nothin but a thang",
             },
         ]
@@ -74,14 +74,14 @@ def test_langtool_load():
         for match_i, match in enumerate(matches):
             assert isinstance(match, language_tool_python.Match)
             for key in [
-                "ruleId",
+                "rule_id",
                 "message",
-                "offsetInContext",
+                "offset_in_context",
                 "context",
                 "offset",
-                "errorLength",
+                "error_length",
                 "category",
-                "ruleIssueType",
+                "rule_issue_type",
                 "sentence",
             ]:
                 assert expected_matches[match_i][key] == getattr(match, key)
@@ -296,7 +296,7 @@ def test_remote_es():
             matches = tool.check(es_text)
             assert (
                 str(matches)
-                == """[Match({'ruleId': 'AFRENTAR_DIFICULTADES', 'message': 'Confusión entre «afrontar» y «afrentar».', 'replacements': ['afrontar'], 'offsetInContext': 43, 'context': '...n texto aquí. LanguageTool le ayudará a afrentar algunas dificultades propias de la escr...', 'offset': 49, 'errorLength': 8, 'category': 'INCORRECT_EXPRESSIONS', 'ruleIssueType': 'grammar', 'sentence': 'LanguageTool le ayudará a afrentar algunas dificultades propias de la escritura.'}), Match({'ruleId': 'PRON_HABER_PARTICIPIO', 'message': 'El v. ‘haber’ se escribe con hache.', 'replacements': ['ha'], 'offsetInContext': 43, 'context': '...ificultades propias de la escritura. Se a hecho un esfuerzo para detectar errores...', 'offset': 107, 'errorLength': 1, 'category': 'MISSPELLING', 'ruleIssueType': 'misspelling', 'sentence': 'Se a hecho un esfuerzo para detectar errores tipográficos, ortograficos y incluso gramaticales.'}), Match({'ruleId': 'MORFOLOGIK_RULE_ES', 'message': 'Se ha encontrado un posible error ortográfico.', 'replacements': ['ortográficos', 'ortográficas', 'ortográfico', 'orográficos', 'ortografiaos', 'ortografíeos'], 'offsetInContext': 43, 'context': '...rzo para detectar errores tipográficos, ortograficos y incluso gramaticales. También algunos...', 'offset': 163, 'errorLength': 12, 'category': 'TYPOS', 'ruleIssueType': 'misspelling', 'sentence': 'Se a hecho un esfuerzo para detectar errores tipográficos, ortograficos y incluso gramaticales.'}), Match({'ruleId': 'Y_E_O_U', 'message': 'Cuando precede a palabras que comienzan por ‘i’, la conjunción ‘y’ se transforma en ‘e’.', 'replacements': ['e'], 'offsetInContext': 43, 'context': '...ctar errores tipográficos, ortograficos y incluso gramaticales. También algunos e...', 'offset': 176, 'errorLength': 1, 'category': 'GRAMMAR', 'ruleIssueType': 'grammar', 'sentence': 'Se a hecho un esfuerzo para detectar errores tipográficos, ortograficos y incluso gramaticales.'}), Match({'ruleId': 'GROSSO_MODO', 'message': 'Esta expresión latina se usa sin preposición.', 'replacements': ['grosso modo'], 'offsetInContext': 43, 'context': '...les. También algunos errores de estilo, a grosso modo.', 'offset': 235, 'errorLength': 13, 'category': 'GRAMMAR', 'ruleIssueType': 'grammar', 'sentence': 'También algunos errores de estilo, a grosso modo.'})]"""
+                == """[Match({'rule_id': 'AFRENTAR_DIFICULTADES', 'message': 'Confusión entre «afrontar» y «afrentar».', 'replacements': ['afrontar'], 'offset_in_context': 43, 'context': '...n texto aquí. LanguageTool le ayudará a afrentar algunas dificultades propias de la escr...', 'offset': 49, 'error_length': 8, 'category': 'INCORRECT_EXPRESSIONS', 'rule_issue_type': 'grammar', 'sentence': 'LanguageTool le ayudará a afrentar algunas dificultades propias de la escritura.'}), Match({'rule_id': 'PRON_HABER_PARTICIPIO', 'message': 'El v. ‘haber’ se escribe con hache.', 'replacements': ['ha'], 'offset_in_context': 43, 'context': '...ificultades propias de la escritura. Se a hecho un esfuerzo para detectar errores...', 'offset': 107, 'error_length': 1, 'category': 'MISSPELLING', 'rule_issue_type': 'misspelling', 'sentence': 'Se a hecho un esfuerzo para detectar errores tipográficos, ortograficos y incluso gramaticales.'}), Match({'rule_id': 'MORFOLOGIK_RULE_ES', 'message': 'Se ha encontrado un posible error ortográfico.', 'replacements': ['ortográficos', 'ortográficas', 'ortográfico', 'orográficos', 'ortografiaos', 'ortografíeos'], 'offset_in_context': 43, 'context': '...rzo para detectar errores tipográficos, ortograficos y incluso gramaticales. También algunos...', 'offset': 163, 'error_length': 12, 'category': 'TYPOS', 'rule_issue_type': 'misspelling', 'sentence': 'Se a hecho un esfuerzo para detectar errores tipográficos, ortograficos y incluso gramaticales.'}), Match({'rule_id': 'Y_E_O_U', 'message': 'Cuando precede a palabras que comienzan por ‘i’, la conjunción ‘y’ se transforma en ‘e’.', 'replacements': ['e'], 'offset_in_context': 43, 'context': '...ctar errores tipográficos, ortograficos y incluso gramaticales. También algunos e...', 'offset': 176, 'error_length': 1, 'category': 'GRAMMAR', 'rule_issue_type': 'grammar', 'sentence': 'Se a hecho un esfuerzo para detectar errores tipográficos, ortograficos y incluso gramaticales.'}), Match({'rule_id': 'GROSSO_MODO', 'message': 'Esta expresión latina se usa sin preposición.', 'replacements': ['grosso modo'], 'offset_in_context': 43, 'context': '...les. También algunos errores de estilo, a grosso modo.', 'offset': 235, 'error_length': 13, 'category': 'GRAMMAR', 'rule_issue_type': 'grammar', 'sentence': 'También algunos errores de estilo, a grosso modo.'})]"""
             )
     except RateLimitError:
         print("Rate limit error: skipping test about public API.")
@@ -348,7 +348,7 @@ def test_session_only_new_spellings():
     new_spellings = ["word1", "word2", "word3"]
     with language_tool_python.LanguageTool(
         "en-US",
-        newSpellings=new_spellings,
+        new_spellings=new_spellings,
         new_spellings_persist=False,
     ) as tool:
         tool.enabled_rules_only = True


### PR DESCRIPTION
# fix: from camel case to snake case for some params and attribs (breaking)

## Why the pull request was made
To comply with Python best practices, and take advantage of the upcoming version change with other breaking changes to do so.

## Summary of changes
- Changed some attribs and params names from camel case to snake case (and linked refs)
- Excluded .readthedocs.yaml from build #133 
- Changed the way of creating a set for a var
- Replaced list and random shuffle by random sample

## Screenshots (if appropriate):
Not applicable

## How has this been tested?
Applied local tests.

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
