### PR TITLE
feat (ruff): added some rules to ruff (N, S, BLE), corrected S and N warns

### DIFF
--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -628,7 +628,7 @@ class LanguageTool:
             )
             raise PathError(err) from e
         else:
-            self._server = subprocess.Popen(
+            self._server = subprocess.Popen(  # noqa: S603  # server_cmd is constructed internally -> trusted
                 server_cmd,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.DEVNULL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,10 @@ packages = { find = { include = ["language_tool_python*"] } }
 language_tool_python = ["py.typed", "logging.toml"]
 
 [tool.ruff.lint]
-select = ["F", "W", "I", "B", "SIM", "RET", "Q"]
+select = ["F", "W", "I", "B", "SIM", "RET", "Q", "N", "S", "BLE"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["S101"]
 
 [tool.mypy]
 files = ["language_tool_python"]

--- a/tests/test_major_functionality.py
+++ b/tests/test_major_functionality.py
@@ -370,8 +370,8 @@ def test_session_only_new_spellings():
 def test_disabled_rule_in_config():
     import language_tool_python
 
-    GRAMMAR_TOOL_CONFIG = {"disabledRuleIds": ["MORFOLOGIK_RULE_EN_US"]}
-    with language_tool_python.LanguageTool("en-US", config=GRAMMAR_TOOL_CONFIG) as tool:
+    grammar_tool_config = {"disabledRuleIds": ["MORFOLOGIK_RULE_EN_US"]}
+    with language_tool_python.LanguageTool("en-US", config=grammar_tool_config) as tool:
         text = "He realised that the organization was in jeopardy."
         matches = tool.check(text)
         assert len(matches) == 0


### PR DESCRIPTION
# feat (ruff): added some rules to ruff (N, S, BLE), corrected S and N warns

## Why the pull request was made
To add some rules of good practice in ruff (good conventions or security).

## Summary of changes
- Added S, N and BLE rules in ruff
- Corrected some S warns (timeout and Popen)
- Corrected one N warn in tests (naming convention for a var)

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied local tests.

## Resources
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [x] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
