### PR TITLE
refactor: replaced os.path uses by pathlib

### DIFF
--- a/language_tool_python/config_file.py
+++ b/language_tool_python/config_file.py
@@ -2,7 +2,6 @@
 
 import atexit
 import logging
-import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -246,6 +245,6 @@ class LanguageToolConfig:
         logger.debug("Created temporary LanguageTool config file at %s", temp_name)
 
         # Remove file when program exits.
-        atexit.register(lambda: os.unlink(temp_name))
+        atexit.register(lambda: Path(temp_name).unlink(missing_ok=True))
 
         return temp_name

--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -5,13 +5,13 @@ import contextlib
 import http.client
 import json
 import logging
-import os
 import random
 import socket
 import subprocess
 import time
 import urllib.parse
 import warnings
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Set
 
 import psutil
@@ -410,7 +410,7 @@ class LanguageTool:
         self.disabled_categories.update(self._spell_checking_categories)
 
     @staticmethod
-    def _get_valid_spelling_file_path() -> str:
+    def _get_valid_spelling_file_path() -> Path:
         """
         Retrieve the valid file path for the spelling file.
         This function constructs the file path for the spelling file used by the
@@ -420,14 +420,19 @@ class LanguageTool:
         :raises FileNotFoundError: If the spelling file does not exist at the
                                    constructed path.
         :return: The valid file path for the spelling file.
-        :rtype: str
+        :rtype: Path
         """
         library_path = get_language_tool_directory()
-        spelling_file_path = os.path.join(
-            library_path,
-            "org/languagetool/resource/en/hunspell/spelling.txt",
+        spelling_file_path = (
+            library_path
+            / "org"
+            / "languagetool"
+            / "resource"
+            / "en"
+            / "hunspell"
+            / "spelling.txt"
         )
-        if not os.path.exists(spelling_file_path):
+        if not spelling_file_path.exists():
             err = (
                 f"Failed to find the spellings file at {spelling_file_path}\n"
                 " Please file an issue at "

--- a/tests/test_major_functionality.py
+++ b/tests/test_major_functionality.py
@@ -332,14 +332,18 @@ def test_spellcheck_en_gb():
 
 def test_session_only_new_spellings():
     import hashlib
-    import os
 
     import language_tool_python
 
     library_path = language_tool_python.utils.get_language_tool_directory()
-    spelling_file_path = os.path.join(
-        library_path,
-        "org/languagetool/resource/en/hunspell/spelling.txt",
+    spelling_file_path = (
+        library_path
+        / "org"
+        / "languagetool"
+        / "resource"
+        / "en"
+        / "hunspell"
+        / "spelling.txt"
     )
     with open(spelling_file_path, "r") as spelling_file:
         initial_spelling_file_contents = spelling_file.read()


### PR DESCRIPTION
# refactor: replaced os.path uses by pathlib

## Why the pull request was made
This PR replaces all usage of `os.path` with `pathlib.Path`, the modern and recommended API for filesystem path handling.

## Summary of changes
- Replaced `os.unlink` and `os.remove` by `Path().unlink`
- Replaced `str` returns by `Path` returns
- Replaced `os.makedirs` by `Path().mkdirs`
- Replaced `os.path.isdir` by `Path().is_dir`
- Replaced `os.path.isfile` by `Path().is_file`
- Replaced `os.path.splitext` by `Path().name` and `Path().stem`
- Replaced `os.path.join` by `/` operator
- Corrected a bug to choose the latest installed LT version

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied local tests, prints.

## Resources
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [x] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
