### PR TITLE
fix: wait for process terminaison to avoid zombies

### DIFF
--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -55,9 +55,12 @@ def _kill_processes(processes: List[subprocess.Popen[str]]) -> None:
     :param processes: A list of subprocess.Popen objects representing the running server processes.
     :type processes: List[subprocess.Popen]
     """
-    for pid in [p.pid for p in processes]:
+    for p in processes:
         with contextlib.suppress(psutil.NoSuchProcess):
-            kill_process_force(pid=pid)
+            kill_process_force(pid=p.pid)
+        # Wait to avoid zombies
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            p.wait(timeout=5)
 
 
 class LanguageTool:


### PR DESCRIPTION
# fix: wait for process terminaison to avoid zombies

## Why the pull request was made
Currently, under UNIX, LanguageTool processes that are terminated remain in zombie mode because the parent process does not read the return code.
To prevent these processes from remaining in the process table and not being cleaned up properly, reading the return code has been added.

## Summary of changes
- Added a `wait` after each LT processus terminaison, in the `language_tool_python.server._kill_processes` func.

## Screenshots (if appropriate):

Current behaviour. If the parent process continues to run even after LT being killed, it remains in zombie mode:
<img width="1881" height="21" alt="image" src="https://github.com/user-attachments/assets/e9d2028c-ff13-4f38-af10-93c90dc0df6d" />

## How has this been tested?
Applied existing tests, and checked behaviour with `htop`.

## Resources
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
