### PR TITLE
fix(server): permit to register new spellings for other languages than en

### DIFF
--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -207,10 +207,10 @@ class LanguageTool:
                 language = get_locale_language()
             except ValueError:
                 language = FAILSAFE_LANGUAGE
+        self._language = LanguageTag(language, self._get_languages())
         if new_spellings:
             self._new_spellings = new_spellings
             self._register_spellings()
-        self._language = LanguageTag(language, self._get_languages())
         self._mother_tongue = mother_tongue
         self._disabled_rules = set()
         self._enabled_rules = set()
@@ -736,12 +736,24 @@ class LanguageTool:
             raise PathError(err)
         library_path = self._local_language_tool.get_directory_path()
 
+        language = self._language.normalized_tag.split("-")[
+            0
+        ].lower()  # if language is "en-US", we want "en"
+
+        if language == "auto":
+            # Default to English if auto is selected, as the spelling file is needed for new spellings
+            # The new spellings will only be taken into account if the server detects the language as English
+            logger.debug(
+                "Language is set to 'auto'. Defaulting to 'en' for spelling file path."
+            )
+            language = "en"
+
         spelling_file_path = (
             library_path
             / "org"
             / "languagetool"
             / "resource"
-            / "en"
+            / language
             / "hunspell"
             / "spelling.txt"
         )

--- a/tests/test_server_local.py
+++ b/tests/test_server_local.py
@@ -124,6 +124,25 @@ def test_session_only_new_spellings() -> None:
     assert initial_checksum.hexdigest() == subsequent_checksum.hexdigest()
 
 
+def test_new_spellins_in_es() -> None:
+    """
+    Test that new spellings are recognized in Spanish language.
+    This test verifies that when new_spellings are added for the Spanish language,
+    they are correctly recognized by the tool during grammar checking.
+    (This test is important to ensure that the new spellings functionality works
+    across different languages and is not limited to English.)
+
+    :raises AssertionError: If the new spellings are not recognized in Spanish.
+    """
+    import language_tool_python
+
+    with language_tool_python.LanguageTool(
+        "es", new_spellings=["ejempo"], new_spellings_persist=False
+    ) as tool:
+        matches = tool.check("Este es un ejempo sencillo.")
+        assert not matches
+
+
 def test_uk_typo() -> None:
     """
     Test grammar checking and correction with UK English language rules.


### PR DESCRIPTION
# fix(server): permit to register new spellings for other languages than en

## Why the pull request was made
To fix a bug that restrict the addition of words to english.
If you give `new_spellings` to `LanguageTool` with, for exemple, `es` as language, the `new_spellings` will be added in the english dict, and so, the custom words will not be taken into acount.

## Summary of changes
- In `language_tool_python.server.LanguageTool._get_valid_spelling_file_path`, find the spelling file depending on the language of the current server.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
By applying local tests, and by testing to add accepted words in some languages.

## Resources
[This commit](https://github.com/vfigueroa-nur/language_tool_python/commit/5e12d9f06ed0682b0a181c59edf1c68bfd50ad05) on the fork of @vfigueroa-nur allowed me to detect this bug.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
