### PR TITLE
chore: bump LT release version related to snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It can:
 - call your own remote LanguageTool server,
 - be used from Python code and from a CLI.
 
-Default local download target: `latest` snapshot (currently `6.8-SNAPSHOT`).
+Default local download target: `latest` snapshot (currently `6.9-SNAPSHOT`).
 
 ## Documentation
 
@@ -90,7 +90,7 @@ with language_tool_python.LanguageTool(
 ```
 
 Accepted formats:
-- `latest` (default): latest snapshot configured by this package (`6.8-SNAPSHOT` at the moment)
+- `latest` (default): latest snapshot configured by this package (`6.9-SNAPSHOT` at the moment)
 - `YYYYMMDD`: snapshot by date (example: `20260201`)
 - `X.Y`: release version (example: `6.7`, `4.0`)
 
@@ -317,7 +317,7 @@ Example:
 
 ```bash
 export LTP_PATH=/path/to/cache
-export LTP_JAR_DIR_PATH=/path/to/LanguageTool-6.8-SNAPSHOT
+export LTP_JAR_DIR_PATH=/path/to/LanguageTool-6.9-SNAPSHOT
 ```
 
 ## Resource Management

--- a/language_tool_python/download_lt.py
+++ b/language_tool_python/download_lt.py
@@ -48,7 +48,7 @@ BASE_URL_ARCHIVE = os.environ.get(
 FILENAME_RELEASE = "LanguageTool-{version}.zip"
 
 LTP_DOWNLOAD_VERSION = "latest"
-LT_SNAPSHOT_CURRENT_VERSION = "6.8-SNAPSHOT"
+LT_SNAPSHOT_CURRENT_VERSION = "6.9-SNAPSHOT"
 
 JAVA_VERSION_REGEX = re.compile(
     r'^(?:java|openjdk) version "(?P<major1>\d+)(|\.(?P<major2>\d+)\.[^"]+)"',


### PR DESCRIPTION
# chore: bump LT release version related to snapshots

## Why the pull request was made
A new tag is available on LanguageTool repo (6.8). So, snapshots versions are now related to future 6.9 version.
Bumping it in our repo allows users to download automatically the latest version in their env.

## Summary of changes
- Bumped the `LT_SNAPSHOT_CURRENT_VERSION` and some references in the `REAMDE.md`.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied tests.

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [x] Other (please describe): chore update

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
