### PR TITLE
ci: bump some ci dependencies versions and fix makefile commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,21 +21,21 @@ jobs:
 
     steps:
     - name: Clone repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6.0.2
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
     
-    - name: Set up JDK 25
-      uses: actions/setup-java@v5
+    - name: Set up JDK 26
+      uses: actions/setup-java@v5.2.0
       with:
         distribution: 'temurin'
-        java-version: '25'
+        java-version: '26'
 
     - name: Install dependencies & build package
       run: |
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
         
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
 
       # Keep in sync ruff version with .pre-commit-config.yaml
       - name: Run Ruff Linter
@@ -76,10 +76,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
         
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Set up venv
         run: uv venv .venv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,8 @@ jobs:
       # Keep in sync ruff version with .pre-commit-config.yaml
       - name: Run Ruff Linter
         run: |
-          uvx ruff@0.14.5 check .
-          uvx ruff@0.14.5 format --check .
+          uvx ruff@0.15.12 check .
+          uvx ruff@0.15.12 format --check .
   
   type_check:
     name: Type Check with Mypy
@@ -94,4 +94,4 @@ jobs:
       # Keep in sync mypy version with .pre-commit-config.yaml
       - name: Run Mypy Type Checker
         run: | 
-          uvx mypy@1.18.2
+          uvx mypy@2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Ruff for linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.5 # Keep in sync with GitHub Actions workflow
+    rev: v0.15.12 # Keep in sync with GitHub Actions workflow
     hooks:
       # Run the linter
       - id: ruff
@@ -11,7 +11,7 @@ repos:
 
   # mypy for type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2 # Keep in sync with GitHub Actions workflow
+    rev: v2.0.0 # Keep in sync with GitHub Actions workflow
     hooks:
       - id: mypy
         args: [--config-file=pyproject.toml]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ The documentation style used in the project is **ReStructuredText**. Please, if 
 Before creating your pull request, when you have made all your commits, you need to run this:
 ```shell
 # Run linters (maybe you will have to fix some issues)
-uvx ruff@0.14.5 check .
+uvx ruff@0.14.5 check language_tool_python tests
 
 # Format code
-uvx ruff@0.14.5 format .
+uvx ruff@0.14.5 format language_tool_python tests
 
 # Check types
 uvx mypy@1.18.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,13 +31,13 @@ The documentation style used in the project is **ReStructuredText**. Please, if 
 Before creating your pull request, when you have made all your commits, you need to run this:
 ```shell
 # Run linters (maybe you will have to fix some issues)
-uvx ruff@0.14.5 check language_tool_python tests
+uvx ruff@0.15.12 check language_tool_python tests
 
 # Format code
-uvx ruff@0.14.5 format language_tool_python tests
+uvx ruff@0.15.12 format language_tool_python tests
 
 # Check types
-uvx mypy@1.18.2
+uvx mypy@2.0.0
 
 # Tests
 pytest

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ default:
 	@exit 1
 
 check:
-	uvx ruff@0.14.5 check language_tool_python tests
-	uvx ruff@0.14.5 format --check language_tool_python tests
-	uvx mypy@1.18.2
+	uvx ruff@0.15.12 check language_tool_python tests
+	uvx ruff@0.15.12 format --check language_tool_python tests
+	uvx mypy@2.0.0
 
 test:
 	pytest

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ default:
 	@exit 1
 
 check:
-	uvx ruff@0.14.5 check .
-	uvx ruff@0.14.5 format --check .
+	uvx ruff@0.14.5 check language_tool_python tests
+	uvx ruff@0.14.5 format --check language_tool_python tests
 	uvx mypy@1.18.2
 
 test:

--- a/README.md
+++ b/README.md
@@ -365,9 +365,9 @@ Main exceptions in `language_tool_python.exceptions`:
 uv sync --group tests --group docs --group types
 
 # Lint / format / types
-uvx ruff@0.14.5 check .
-uvx ruff@0.14.5 format .
-uvx mypy@1.18.2
+uvx ruff@0.15.12 check .
+uvx ruff@0.15.12 format .
+uvx mypy@2.0.0
 
 # Tests
 pytest

--- a/make.bat
+++ b/make.bat
@@ -9,13 +9,13 @@ echo Usage: make.bat [check^|test^|doc^|publish]
 exit /b 1
 
 :check
-uvx ruff@0.14.5 check language_tool_python tests
+uvx ruff@0.15.12 check language_tool_python tests
 if errorlevel 1 exit /b %errorlevel%
 
-uvx ruff@0.14.5 format --check language_tool_python tests
+uvx ruff@0.15.12 format --check language_tool_python tests
 if errorlevel 1 exit /b %errorlevel%
 
-uvx mypy@1.18.2
+uvx mypy@2.0.0
 exit /b %errorlevel%
 
 :test

--- a/make.bat
+++ b/make.bat
@@ -9,10 +9,10 @@ echo Usage: make.bat [check^|test^|doc^|publish]
 exit /b 1
 
 :check
-uvx ruff@0.14.5 check .
+uvx ruff@0.14.5 check language_tool_python tests
 if errorlevel 1 exit /b %errorlevel%
 
-uvx ruff@0.14.5 format --check .
+uvx ruff@0.14.5 format --check language_tool_python tests
 if errorlevel 1 exit /b %errorlevel%
 
 uvx mypy@1.18.2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from typing import Generator, List, Tuple
 import pytest
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     "argv, stdin, should_succeed",
     [
         (["-l", "en-US", "-"], "This is okay.\n", True),
@@ -62,7 +62,7 @@ def test_cli_exit_codes(
         assert code != 0
 
 
-@pytest.fixture(scope="module")  # type: ignore[misc]
+@pytest.fixture(scope="module")  # type: ignore[untyped-decorator]
 def remote_server() -> Generator[Tuple[str, int], None, None]:
     """
     Fixture that provides a remote LanguageTool server for testing.


### PR DESCRIPTION
# ci: bump some ci dependencies versions and fix makefile commands

## Why the pull request was made
To keep up to date the ci dependencies (mypy, ruff, actions in the tests workflow).
The actions in the yml workflow are now fixed (good practice to avoid supply chains cause of auto update when a malicious "bug-fix version" is published by one of these dependencies).

## Summary of changes
- Fix "check" command in the Makefile to target only relevant directories
- Bump `ruff` and `mypy` versions
- Bump CI dependencies and fix the "actions" versions

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied the tests, ran the Makefile commands to ensure that everything works.

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [x] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
