### PR TITLE
fix(server): use POST instead of GET for check endpoint

### DIFF
--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -613,7 +613,7 @@ class LanguageTool:
         """
         url = urllib.parse.urljoin(self._url, "check")
         logger.debug("Sending text to LanguageTool server at %s", url)
-        response = self._query_server(url, self._create_params(text))
+        response = self._query_server(url, self._create_params(text), method="post")
         matches = response["matches"]
         return [Match(match, text) for match in matches]
 
@@ -865,6 +865,7 @@ class LanguageTool:
         url: str,
         params: Optional[Dict[str, str]] = None,
         num_tries: int = 2,
+        method: Literal["get", "post"] = "get",
     ) -> Any:
         """
         Query the server with the given URL and parameters.
@@ -875,6 +876,8 @@ class LanguageTool:
         :type params: Optional[Dict[str, str]], optional
         :param num_tries: The number of times to retry the query in case of failure, defaults to 2.
         :type num_tries: int, optional
+        :param method: HTTP method to use for the request. ``post`` sends params in the request body.
+        :type method: Literal["get", "post"]
         :return: The JSON response from the server.
         :rtype: Any
         :raises LanguageToolError: If the server returns an invalid JSON response or if the query fails after the specified number of retries.
@@ -882,12 +885,21 @@ class LanguageTool:
         logger.debug("_query_server url: %s", url)
         for n in range(num_tries):
             try:
-                with requests.get(
-                    url,
-                    params=params,
-                    timeout=self._TIMEOUT,
-                    proxies=self._proxies,
-                ) as response:
+                if method == "post":
+                    response_context = requests.post(
+                        url,
+                        data=params,
+                        timeout=self._TIMEOUT,
+                        proxies=self._proxies,
+                    )
+                else:
+                    response_context = requests.get(
+                        url,
+                        params=params,
+                        timeout=self._TIMEOUT,
+                        proxies=self._proxies,
+                    )
+                with response_context as response:
                     try:
                         return response.json()
                     except json.decoder.JSONDecodeError as e:


### PR DESCRIPTION
# fix(server): use POST instead of GET for check endpoint

## Why the pull request was made
This PR allows our lib to use the proper method to contact the endpoint, and btw, to avoid having all our params in web server logs (because with get, the params are in the url).

## Summary of changes
- Changed the http verb from get to post for check endpoint.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied local tests.

## Resources
- https://languagetool.org/http-api/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
