### PR TITLE
docs(CI): remove legacy doc in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: language_tool_python CI
 
 permissions:
@@ -56,7 +53,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # 8.1.0
 
-      # Keep in sync ruff version with .pre-commit-config.yaml
       - name: Run Ruff Linter
         run: |
           make ruff-check
@@ -72,7 +68,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # 8.1.0
           
-      # Keep in sync mypy version with .pre-commit-config.yaml
       - name: Run Mypy Type Checker
         run: | 
           make mypy-check


### PR DESCRIPTION
# docs(CI): remove legacy doc in test.yml

## Why the pull request was made
To remove legacy doc in the CI yml, and avoid confusions later.

## Summary of changes
- Remove reminders about mypy and ruff update that are not applicable anymore in this file
- Remove a legacy comment at the top of the file about using python in github actions

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Not applicable.

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
