### PR TITLE
refactor: harden mypy rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,8 @@ ignore = [
 
 [tool.mypy]
 files = ["language_tool_python", "tests"]
+disallow_any_decorated = true
+disallow_any_explicit = true
 disallow_any_expr = true
 disallow_any_generics = true
 disallow_any_unimported = true
@@ -162,6 +164,7 @@ no_implicit_reexport = true
 pretty = true
 show_error_codes = true
 strict_equality = true
+strict_equality_for_none = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -572,7 +572,7 @@ def test_install_oldest_supported_version() -> None:
             "en-US",
             language_tool_download_version="4.0",
         ) as tool:
-            assert tool is not None
+            assert tool.language_tool_download_version == "4.0"
     except LanguageToolError:
         pytest.fail("Failed to download or initialize the oldest supported version.")
 
@@ -592,7 +592,9 @@ def test_install_snapshot_version() -> None:
                 (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y%m%d")
             ),
         ) as tool:
-            assert tool is not None
+            assert tool.language_tool_download_version == (
+                datetime.now(timezone.utc) - timedelta(days=3)
+            ).strftime("%Y%m%d")
     except LanguageToolError:
         pytest.skip(
             (

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ docs = [
     { name = "sphinx-design" },
 ]
 quality = [
-    { name = "mypy", marker = "python_full_version >= '3.10'", specifier = "==2.1.0" },
+    { name = "mypy", specifier = "==2.1.0" },
     { name = "ruff", specifier = "==0.15.16" },
 ]
 tests = [
@@ -1145,14 +1145,14 @@ wheels = [
 
 [[package]]
 name = "tqdm"
-version = "4.68.1"
+version = "4.68.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/b3/36c8ecf72e8925200671613332db156d84b99b3aee742a41c1938ebb0808/tqdm-4.68.1.tar.gz", hash = "sha256:fc163d96b287bd031e1aa24421ce4411b25559bd0a1be4fe649bdaa4d2c02bf5", size = 171236, upload-time = "2026-06-05T17:23:15.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/aa/218a0eb34de1f753c83e4d0d1c8e7c4cef27f20dcb8342e024f63a80dc86/tqdm-4.68.1-py3-none-any.whl", hash = "sha256:fea4a90e4023f764914569f7802a297277c5ab1a66be5144143e142e1a4031d8", size = 78354, upload-time = "2026-06-05T17:23:13.654Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# refactor: harden mypy rules

## Why the pull request was made
In the continuity of #181, harden mypy configuration to ensure proper typing errors detection.

## Summary of changes
- Add new rules in `mypy` configuration.
- Patch new warnings triggered by new rules.
- `uv.lock` upgrade to ensure that the lock file is fully compatible with the previous PR #182.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied local tests.

## Resources
https://mypy.readthedocs.io/en/stable/config_file.html

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [x] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
