### PR TITLE
feat(server): add the possibility to attach an api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ with language_tool_python.LanguageToolPublicAPI("es") as tool:
     print(matches)
 ```
 
+#### Public LanguageTool API with an API key
+
+If you have a LanguageTool API key, set `premium_key` before calling `check()`:
+
+```python
+import os
+
+import language_tool_python
+
+with language_tool_python.LanguageToolPublicAPI("en-US") as tool:
+    tool.premium_key = os.environ["LANGUAGETOOL_API_KEY"]
+    matches = tool.check("This are bad.")
+    print(matches)
+```
+
+The key is sent to the public API as `apiKey` for each request.
+
 ### Your own remote LanguageTool server
 
 ```python

--- a/language_tool_python/server.py
+++ b/language_tool_python/server.py
@@ -207,6 +207,9 @@ class LanguageTool:
     _proxies: dict[str, str] | None
     """A dictionary of proxies for network requests (used in requests to the server)."""
 
+    _premium_key: str | None
+    """The premium API key for the LanguageTool API."""
+
     def __init__(  # noqa: PLR0913  # Too many arguments, but they are all necessary for configuring the server. Maybe refactor in a future breaking release to use a configuration object instead of individual parameters.
         self,
         language: str | None = None,
@@ -285,6 +288,7 @@ class LanguageTool:
         self._enabled_rules_only = False
         self._preferred_variants = set()
         self._picky = False
+        self._premium_key = None
 
     def __enter__(self) -> LanguageTool:
         """Enter the runtime context related to this object.
@@ -578,6 +582,24 @@ class LanguageTool:
         self._picky = value
 
     @property
+    def premium_key(self) -> str | None:
+        """Get the premium API key.
+
+        :return: The premium API key if set, otherwise None.
+        :rtype: str | None
+        """
+        return self._premium_key
+
+    @premium_key.setter
+    def premium_key(self, value: str | None) -> None:
+        """Set the premium API key.
+
+        :param value: The premium API key.
+        :type value: str | None
+        """
+        self._premium_key = value
+
+    @property
     def config(self) -> LanguageToolConfig | None:
         """Get the server configuration.
 
@@ -756,6 +778,8 @@ class LanguageTool:
             params["preferredVariants"] = ",".join(self._preferred_variants)
         if self._picky:
             params["level"] = "picky"
+        if self._premium_key:
+            params["apiKey"] = self._premium_key
         return params
 
     def correct(self, text: str) -> str:


### PR DESCRIPTION
# feat(server): add the possibility to attach an api key

## Why the pull request was made
To permit to users who have premium tokens to use the library with them.

## Summary of changes
- Add a `premium_key` attribute in `LanguageTool` class.
- Use this attribute in `LanguageTool._create_params`
- Edit documentation to mention it.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
With local tests. Miss an API key to test the feature.

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
