### PR TITLE
ci(test.yml): migrate runners from ubuntu 24.04 to 26.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,17 +21,17 @@ jobs:
         # Execute tests on python 3.10-3.15 on ubuntu
         # and python 3.14 on macOS and windows
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             python-version: "3.10"
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             python-version: "3.11"
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             python-version: "3.12"
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             python-version: "3.13"
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             python-version: "3.14"
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             python-version: "3.15.0-beta.2"
           - os: macos-26
             python-version: "3.14"
@@ -39,14 +39,6 @@ jobs:
             python-version: "3.14"
 
     steps:
-    - name: Clone repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0
-      with:
-        python-version: ${{ matrix.python-version }}
-
     - name: Install uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
     
@@ -56,20 +48,27 @@ jobs:
         distribution: 'temurin'
         java-version: '26'
 
+    - name: Clone repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
+      with:
+        persist-credentials: false
+
     - name: Test with pytest
       run: |
-        uv run --group tests --locked pytest
+        uv run --python ${{ matrix.python-version }} --group tests --locked pytest
 
   lint:
     timeout-minutes: 10
     name: Lint with Ruff
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
-      - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
-        
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+
+      - name: Clone repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
+        with:
+          persist-credentials: false
 
       - name: Run Ruff Linter
         run: |
@@ -78,14 +77,16 @@ jobs:
   type_check:
     timeout-minutes: 10
     name: Type Check with Mypy
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
-      - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
-        
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-          
+
+      - name: Clone repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
+        with:
+          persist-credentials: false
+
       - name: Run Mypy Type Checker
         run: | 
           make mypy-check


### PR DESCRIPTION
# ci(test.yml): migrate runners from ubuntu 24.04 to 26.04

## Why the pull request was made
To keep up to date CI's runners.

## Summary of changes
- Change versions of runners from ubuntu 24.04 to ubuntu 26.04.
- Remove `setup-python` action because we can set up Python with `setup-uv`.
- Move config actions (`setup-uv`, `setup-java`) before `checkout` action (no need to clone the repo before tools config).
- Set `persist-credentials` to false for `checkout` actions (useless because these tokens are "read-only", but good practice, especially if we perform some changes in the future with new permissions).

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Not applicable.

## Resources
Runners: https://github.com/actions/runner-images

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [x] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
