### PR TITLE
docs(sphinx): fix copyright year

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "language_tool_python"
-copyright = "2025, jxmorris12"
+copyright = "2026, jxmorris12"  # Keep in sync with LICENSE
 author = "jxmorris12"
 release = "3.4.0"  # Keep in sync with pyproject.toml
 


### PR DESCRIPTION
# docs(sphinx): fix copyright year

## Why the pull request was made
To fix the copyright year in the sphinx docs that I forgot to edit.

## Summary of changes
- Copyright year in sphinx docs from 2026 to 2026.
- Add a comment in the docs conf file to remember to sync this copyright year with the license.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Not applicable.

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
