### PR TITLE
fix(config_file): allow directories in _path_validator

### DIFF
--- a/language_tool_python/config_file.py
+++ b/language_tool_python/config_file.py
@@ -141,19 +141,19 @@ def _path_encoder(v: PathLike[str] | str) -> str:
 
 
 def _path_validator(v: PathLike[str] | str) -> None:
-    """Validate that a given path exists and is a file.
+    """Validate that a given path exists and is a file or directory.
 
     :param v: The path to validate, which will be converted to a Path object
     :type v: PathLike[str] | str
     :raises PathError: If the path does not exist
-    :raises PathError: If the path exists but is not a file
+    :raises PathError: If the path exists but is not a file or directory
     """
     p = Path(v)
     if not p.exists():
         err = f"path does not exist: {p}"
         raise PathError(err)
-    if not p.is_file():
-        err = f"path is not a file: {p}"
+    if not p.is_file() and not p.is_dir():
+        err = f"path is not a file/directory: {p}"
         raise PathError(err)
 
 


### PR DESCRIPTION
# fix(config_file): allow directories in _path_validator

## Why the pull request was made
Because directories are not allowed for config values that are path, which is problematic for config values like `languageModel`.

## Summary of changes
- Allow directories in `config_file._path_validator`

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Tested with concerned config values.

## Resources
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
