### PR TITLE
fix(server): add missing username to auth as premium user

### DIFF
--- a/docs/source/references/advanced.rst
+++ b/docs/source/references/advanced.rst
@@ -37,10 +37,11 @@ Accepted formats:
 Authenticating with a premium API key
 --------------------------------------
 
-If you have a LanguageTool premium key, assign it to
+If you have a LanguageTool premium account, assign your username and API key to
+:attr:`~language_tool_python.server.LanguageTool.premium_username` and
 :attr:`~language_tool_python.server.LanguageTool.premium_key` before calling
-:meth:`~language_tool_python.server.LanguageTool.check`. The key is forwarded to the
-public API as the ``apiKey`` parameter:
+:meth:`~language_tool_python.server.LanguageTool.check`. They are forwarded to the
+public API as the ``username`` and ``apiKey`` parameters respectively:
 
 .. code-block:: python
 
@@ -48,6 +49,7 @@ public API as the ``apiKey`` parameter:
    import language_tool_python
 
    with language_tool_python.LanguageToolPublicAPI("en-US") as tool:
+       tool.premium_username = os.environ["LANGUAGETOOL_USERNAME"]
        tool.premium_key = os.environ["LANGUAGETOOL_API_KEY"]
        print(tool.correct("A sentence with a error in the Hitchhiker's Guide tot he Galaxy"))
        # → A sentence with an error in the Hitchhiker's Guide to the Galaxy

--- a/src/language_tool_python/server.py
+++ b/src/language_tool_python/server.py
@@ -210,6 +210,9 @@ class LanguageTool:
     _proxies: dict[str, str] | None
     """A dictionary of proxies for network requests (used in requests to the server)."""
 
+    _premium_username: str | None
+    """The premium API username for the LanguageTool API."""
+
     _premium_key: str | None
     """The premium API key for the LanguageTool API."""
 
@@ -291,6 +294,7 @@ class LanguageTool:
         self._enabled_rules_only = False
         self._preferred_variants = set()
         self._picky = False
+        self._premium_username = None
         self._premium_key = None
 
     def __enter__(self) -> LanguageTool:
@@ -586,6 +590,24 @@ class LanguageTool:
         self._picky = value
 
     @property
+    def premium_username(self) -> str | None:
+        """Get the premium API username.
+
+        :return: The premium API username if set, otherwise None.
+        :rtype: str | None
+        """
+        return self._premium_username
+
+    @premium_username.setter
+    def premium_username(self, value: str | None) -> None:
+        """Set the premium API username.
+
+        :param value: The premium API username.
+        :type value: str | None
+        """
+        self._premium_username = value
+
+    @property
     def premium_key(self) -> str | None:
         """Get the premium API key.
 
@@ -740,7 +762,7 @@ class LanguageTool:
 
         return sorted(all_matches, key=_match_offset)
 
-    def _create_params(self, text: str) -> dict[str, str]:
+    def _create_params(self, text: str) -> dict[str, str]:  # noqa: C901  # Too complex, but it needs to handle many different parameters for the server request.
         """Create a dictionary of parameters for the language tool server request.
 
         :param text: The text to be checked.
@@ -782,6 +804,8 @@ class LanguageTool:
             params["preferredVariants"] = ",".join(self._preferred_variants)
         if self._picky:
             params["level"] = "picky"
+        if self._premium_username:
+            params["username"] = self._premium_username
         if self._premium_key:
             params["apiKey"] = self._premium_key
         return params


### PR DESCRIPTION
# fix(server): add missing username to auth as premium user

## Why the pull request was made
To patch the "premium" functionality, and allow users to authenticate as premium users to LT public API.

## Summary of changes
- Add a new `premium_username` attribute to `LanguageTool`.
- Set this attribute in the check request params.
- Adapt existing documentation.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied local tests. Need a premium key to test the functionality.

## Resources
https://languagetool.org/http-api/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
