### PR TITLE
chore(dependabot): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    versioning-strategy: lockfile-only
+    schedule:
+      interval: "weekly"
+    cooldown:
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+  
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 14
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "https://github.com/astral-sh/ruff-pre-commit" # Because we want to keep the ruff version in sync with pyproject.toml
+      - dependency-name: "https://github.com/pre-commit/mirrors-mypy" # Because we want to keep the mypy version in sync with pyproject.toml
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 14
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
# chore(dependabot): add dependabot config

## Why the pull request was made
To have a clean config about dependencies auto-updates.

## Summary of changes
- Add a dependabot config
 - Update `uv.lock` weekly (with a cooldown of 7 days for patches, 14 days for minors and 30 days for majors, to reduce risks of supply chain).
 - Update github-actions monthly (with a cooldown of 14 days, to reduce risks of supply chain).
 - Update pre-commit monthly (with a cooldown of 14 days, to reduce risks of supply chain).

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Not applicable.

## Resources
https://docs.github.com/en/code-security/reference/supply-chain-security

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [x] Chore / maintenance (non-breaking change that does not affect functionality, such as updating dependencies or fixing typos)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
- [x] Added your changes to the [CHANGELOG](./CHANGELOG.md) file, if applicable.
