### PR TITLE
fix(server): update server url when the port change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 ### Fixed
 - Corrected a bug in `language_tool_python.config_file.LanguageToolConfig` where directory paths were incorrectly rejected by the path validator.
+- Fixed a bug in `LanguageTool._start_server_on_free_port` where `_url` was not updated when retrying on a different port, causing all subsequent server requests to target the wrong (original) port.
 
 ### Removed
 - **Breaking:** Removed all functions and classes previously deprecated in v3.3.0:

--- a/src/language_tool_python/server.py
+++ b/src/language_tool_python/server.py
@@ -1101,6 +1101,7 @@ class LanguageTool:
                 if len(self._available_ports) > 0:
                     old_port = self._port
                     self._port = self._available_ports.pop()
+                    self._url = f"http://{self._host}:{self._port}/v2/"
                     logger.debug("Port %s failed, trying port %s", old_port, self._port)
                 else:
                     raise


### PR DESCRIPTION
# fix(server): update server url when the port change

## Why the pull request was made
Because actually, when the server port change, we don't change the server url, and the healthcheck test to ensure that the server is alive will fail.

## Summary of changes
- Update `LanguageTool._url` when we need to change the starting port.

## Screenshots (if appropriate):
Not applicable.

Applied local tests.

## Resources
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Chore / maintenance (non-breaking change that does not affect functionality, such as updating dependencies or fixing typos)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
- [x] Added your changes to the [CHANGELOG](./CHANGELOG.md) file, if applicable.
