### PR TITLE
fix(server): correct poor rate limit responses detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 ### Fixed
 - Corrected a bug in `language_tool_python.config_file.LanguageToolConfig` where directory paths were incorrectly rejected by the path validator.
 - Fixed a bug in `LanguageTool._start_server_on_free_port` where `_url` was not updated when retrying on a different port, causing all subsequent server requests to target the wrong (original) port.
+- Fixed a bug in `LanguageTool._query_server` where `RateLimitError` was only raised when the rate-limit response body was invalid JSON, a valid JSON body with status 426 was silently returned as data instead (for now, the body from LanguageTool for rate-limiting responses is "Upgrade Required", which is not valid JSON, but this may change in the future).
 
 ### Removed
 - **Breaking:** Removed all functions and classes previously deprecated in v3.3.0:

--- a/src/language_tool_python/server.py
+++ b/src/language_tool_python/server.py
@@ -1054,6 +1054,12 @@ class LanguageTool:
                         timeout=self._TIMEOUT,
                     )
                 with response_context as response:
+                    if response.status_code == _HTTP_STATUS_RATE_LIMIT:
+                        err = (
+                            "You have exceeded the rate limit for the free "
+                            "LanguageTool API. Please try again later."
+                        )
+                        raise RateLimitError(err)
                     try:
                         data: object = response.json()
                     except json.decoder.JSONDecodeError as e:
@@ -1063,12 +1069,6 @@ class LanguageTool:
                             e,
                         )
                         logger.debug("Status code: %s", response.status_code)
-                        if response.status_code == _HTTP_STATUS_RATE_LIMIT:
-                            err = (
-                                "You have exceeded the rate limit for the free "
-                                "LanguageTool API. Please try again later."
-                            )
-                            raise RateLimitError(err) from e
                         raise LanguageToolError(
                             _decode_response_content(response),
                         ) from e


### PR DESCRIPTION
# fix(server): correct poor rate limit responses detection

## Why the pull request was made
To have a better detection of rate limit responses, even if the body of the rate limit become a JSON response.

## Summary of changes
- Detect rate limit responses even in JSON responses.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied local tests.

## Resources
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Chore / maintenance (non-breaking change that does not affect functionality, such as updating dependencies or fixing typos)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
- [x] Added your changes to the [CHANGELOG](./CHANGELOG.md) file, if applicable.
