### PR TITLE
fix(server): suppression of a potential raised exception with running processes manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 - Corrected a bug in `language_tool_python.config_file.LanguageToolConfig` where directory paths were incorrectly rejected by the path validator.
 - Fixed a bug in `LanguageTool._start_server_on_free_port` where `_url` was not updated when retrying on a different port, causing all subsequent server requests to target the wrong (original) port.
 - Fixed a bug in `LanguageTool._query_server` where `RateLimitError` was only raised when the rate-limit response body was invalid JSON, a valid JSON body with status 426 was silently returned as data instead (for now, the body from LanguageTool for rate-limiting responses is "Upgrade Required", which is not valid JSON, but this may change in the future).
+- Fixed a bug in `LanguageTool._terminate_server` where `_RUNNING_SERVER_PROCESSES.remove()` could raise `ValueError` if the server process was not yet in the list or was no longer in it.
 
 ### Removed
 - **Breaking:** Removed all functions and classes previously deprecated in v3.3.0:

--- a/src/language_tool_python/server.py
+++ b/src/language_tool_python/server.py
@@ -1226,7 +1226,8 @@ class LanguageTool:
         if self._server:
             logger.info("Terminating LanguageTool server on port %s", self._port)
             _kill_processes([self._server])
-            _RUNNING_SERVER_PROCESSES.remove(self._server)
+            with contextlib.suppress(ValueError):
+                _RUNNING_SERVER_PROCESSES.remove(self._server)
 
             if self._server.stdin:
                 self._server.stdin.close()


### PR DESCRIPTION
# fix(server): suppression of a potential raised exception with running processes manipulation

## Why the pull request was made
To avoid a potential exception raised in the close method of the server, and having a silent close.

## Summary of changes
- Supress a `ValueError` that can be raised in `_RUNNING_SERVER_PROCESSES.remove` if our server is not yet or not anymore in this list.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Applied local tests.

## Resources
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [ ] Chore / maintenance (non-breaking change that does not affect functionality, such as updating dependencies or fixing typos)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
- [x] Added your changes to the [CHANGELOG](./CHANGELOG.md) file, if applicable.
