### PR TITLE
chore(deps): bump uv from 0.11.25 to 0.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,12 @@ quality = [
 language_tool_python = "language_tool_python.__main__:main"
 
 [build-system]
-requires = ["uv_build>=0.11.14,<0.12"]
+requires = ["uv_build>=0.12.1,<0.13"]
 build-backend = "uv_build"
 
 [tool.uv]
 exclude-newer = "7 days"
-required-version = ">=0.11.25,<0.12"
+required-version = ">=0.12.1,<0.13"
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
# chore(deps): bump uv from 0.11.25 to 0.12.1

## Why the pull request was made
To keep up to date the version of uv (and uv_build).

## Summary of changes
- Updated `uv` from `">=0.11.25,<0.12"` to `">=0.12.1,<0.13"`
- Updated `uv_build` from `"">=0.11.14,<0.12""` to `">=0.12.1,<0.13"`

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Built the project, used the makefile.

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [x] Chore / maintenance (non-breaking change that does not affect functionality, such as updating dependencies or fixing typos)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
- [x] Added your changes to the [CHANGELOG](./CHANGELOG.md) file, if applicable.
