### PR TITLE
chore(dependabot): remove exception to avoid mypy and ruff pre-commit updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    ignore:
-      - dependency-name: "https://github.com/astral-sh/ruff-pre-commit" # Because we want to keep the ruff version in sync with pyproject.toml
-      - dependency-name: "https://github.com/pre-commit/mirrors-mypy" # Because we want to keep the mypy version in sync with pyproject.toml
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
# chore(dependabot): remove exception to avoid mypy and ruff pre-commit updates

## Why the pull request was made
To allow dependabot to submit PR to update pre-commit packages of ruff and mypy. I previously wanted to avoid these updates because their versions must be kept up to date with related versions in pyproject.toml, but I can bump the version by hand when dependabot performs a PR.

## Summary of changes
- Removed a rule to avoid updates of precommit ruff and mypy.

## Screenshots (if appropriate):
Not applicable.

## How has this been tested?
Not applicable.

## Resources
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactor / code style update (non-breaking change that improves code structure or readability)
- [ ] Tests / CI improvement (adding or updating tests or CI configuration only)
- [x] Chore / maintenance (non-breaking change that does not affect functionality, such as updating dependencies or fixing typos)
- [ ] Other (please describe):

## Checklist
- [x] Followed the [project's contributing guidelines](../CONTRIBUTING.md).
- [x] Updated any relevant tests.
- [x] Updated any relevant documentation.
- [x] Added comments to your code where necessary.
- [x] Formatted your code, run the linters, checked types and tests.
- [x] Added your changes to the [CHANGELOG](./CHANGELOG.md) file, if applicable.
